### PR TITLE
Prep host-api for docker event integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,3 @@
-image: golang
+image: rancher/dind:v0.2.0
 script:
  - ./scripts/ci

--- a/.wrap-docker-args
+++ b/.wrap-docker-args
@@ -1,0 +1,1 @@
+--privileged

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang
+FROM rancher/dind:v0.2.0
 COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -14,48 +14,47 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/archive",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/fileutils",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/pools",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/promise",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/system",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/units",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
-			"Comment": "v1.3.0-412-gb18efee",
-			"Rev": "b18efeeb7affdd5b920f7aecef8eb83dd1c83d50"
+			"Comment": "v1.5.0",
+			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Comment": "0.2.1-310-ge23bddf",
-			"Rev": "e23bddf4d999bdcb20dfc54b8266ce1159494798"
+			"Rev": "59b423db81e5894ca7460652f1b206fc72d85750"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -1,0 +1,39 @@
+// +build !windows
+
+package archive
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+)
+
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+	s, ok := stat.(*syscall.Stat_t)
+
+	if !ok {
+		err = errors.New("cannot convert stat value to syscall.Stat_t")
+		return
+	}
+
+	nlink = uint32(s.Nlink)
+	inode = uint64(s.Ino)
+
+	// Currently go does not fil in the major/minors
+	if s.Mode&syscall.S_IFBLK == syscall.S_IFBLK ||
+		s.Mode&syscall.S_IFCHR == syscall.S_IFCHR {
+		hdr.Devmajor = int64(major(uint64(s.Rdev)))
+		hdr.Devminor = int64(minor(uint64(s.Rdev)))
+	}
+
+	return
+}
+
+func major(device uint64) uint64 {
+	return (device >> 8) & 0xfff
+}
+
+func minor(device uint64) uint64 {
+	return (device & 0xff) | ((device >> 12) & 0xfff00)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package archive
+
+import (
+	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+)
+
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+	// do nothing. no notion of Rdev, Inode, Nlink in stat on Windows
+	return
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
@@ -135,7 +135,7 @@ func Changes(layers []string, rw string) ([]Change, error) {
 type FileInfo struct {
 	parent     *FileInfo
 	name       string
-	stat       syscall.Stat_t
+	stat       *system.Stat
 	children   map[string]*FileInfo
 	capability []byte
 	added      bool
@@ -168,7 +168,7 @@ func (info *FileInfo) path() string {
 }
 
 func (info *FileInfo) isDir() bool {
-	return info.parent == nil || info.stat.Mode&syscall.S_IFDIR == syscall.S_IFDIR
+	return info.parent == nil || info.stat.Mode()&syscall.S_IFDIR == syscall.S_IFDIR
 }
 
 func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
@@ -199,21 +199,21 @@ func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
 		oldChild, _ := oldChildren[name]
 		if oldChild != nil {
 			// change?
-			oldStat := &oldChild.stat
-			newStat := &newChild.stat
+			oldStat := oldChild.stat
+			newStat := newChild.stat
 			// Note: We can't compare inode or ctime or blocksize here, because these change
 			// when copying a file into a container. However, that is not generally a problem
 			// because any content change will change mtime, and any status change should
 			// be visible when actually comparing the stat fields. The only time this
 			// breaks down is if some code intentionally hides a change by setting
 			// back mtime
-			if oldStat.Mode != newStat.Mode ||
-				oldStat.Uid != newStat.Uid ||
-				oldStat.Gid != newStat.Gid ||
-				oldStat.Rdev != newStat.Rdev ||
+			if oldStat.Mode() != newStat.Mode() ||
+				oldStat.Uid() != newStat.Uid() ||
+				oldStat.Gid() != newStat.Gid() ||
+				oldStat.Rdev() != newStat.Rdev() ||
 				// Don't look at size for dirs, its not a good measure of change
-				(oldStat.Size != newStat.Size && oldStat.Mode&syscall.S_IFDIR != syscall.S_IFDIR) ||
-				!sameFsTimeSpec(system.GetLastModification(oldStat), system.GetLastModification(newStat)) ||
+				(oldStat.Size() != newStat.Size() && oldStat.Mode()&syscall.S_IFDIR != syscall.S_IFDIR) ||
+				!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) ||
 				bytes.Compare(oldChild.capability, newChild.capability) != 0 {
 				change := Change{
 					Path: newChild.path(),
@@ -299,9 +299,11 @@ func collectFileInfo(sourceDir string) (*FileInfo, error) {
 			parent:   parent,
 		}
 
-		if err := syscall.Lstat(path, &info.stat); err != nil {
+		s, err := system.Lstat(path)
+		if err != nil {
 			return err
 		}
+		info.stat = s
 
 		info.capability, _ = system.Lgetxattr(path, "security.capability")
 
@@ -357,14 +359,6 @@ func ChangesSize(newDir string, changes []Change) int64 {
 		}
 	}
 	return size
-}
-
-func major(device uint64) uint64 {
-	return (device >> 8) & 0xfff
-}
-
-func minor(device uint64) uint64 {
-	return (device & 0xff) | ((device >> 12) & 0xfff00)
 }
 
 // ExportChanges produces an Archive from the provided changes, relative to dir.

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes_test.go
@@ -286,7 +286,7 @@ func TestApplyLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ApplyLayer(src, layerCopy); err != nil {
+	if _, err := ApplyLayer(src, layerCopy); err != nil {
 		t.Fatal(err)
 	}
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
@@ -12,27 +12,10 @@ import (
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 
 	"github.com/docker/docker/pkg/pools"
+	"github.com/docker/docker/pkg/system"
 )
 
-// Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
-// They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
-// then the top 12 bits of the minor
-func mkdev(major int64, minor int64) uint32 {
-	return uint32(((minor & 0xfff00) << 12) | ((major & 0xfff) << 8) | (minor & 0xff))
-}
-
-// ApplyLayer parses a diff in the standard layer format from `layer`, and
-// applies it to the directory `dest`.
-func ApplyLayer(dest string, layer ArchiveReader) error {
-	// We need to be able to set any perms
-	oldmask := syscall.Umask(0)
-	defer syscall.Umask(oldmask)
-
-	layer, err := DecompressStream(layer)
-	if err != nil {
-		return err
-	}
-
+func UnpackLayer(dest string, layer ArchiveReader) (size int64, err error) {
 	tr := tar.NewReader(layer)
 	trBuf := pools.BufioReader32KPool.Get(tr)
 	defer pools.BufioReader32KPool.Put(trBuf)
@@ -50,8 +33,10 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			break
 		}
 		if err != nil {
-			return err
+			return 0, err
 		}
+
+		size += hdr.Size
 
 		// Normalize name, for safety and for a simple is-root check
 		hdr.Name = filepath.Clean(hdr.Name)
@@ -65,7 +50,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
 				err = os.MkdirAll(parentPath, 0600)
 				if err != nil {
-					return err
+					return 0, err
 				}
 			}
 		}
@@ -80,24 +65,32 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
 					if aufsTempdir, err = ioutil.TempDir("", "dockerplnk"); err != nil {
-						return err
+						return 0, err
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
 				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true); err != nil {
-					return err
+					return 0, err
 				}
 			}
 			continue
 		}
 
 		path := filepath.Join(dest, hdr.Name)
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return 0, err
+		}
+		if strings.HasPrefix(rel, "..") {
+			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
+		}
 		base := filepath.Base(path)
+
 		if strings.HasPrefix(base, ".wh.") {
 			originalBase := base[len(".wh."):]
 			originalPath := filepath.Join(filepath.Dir(path), originalBase)
 			if err := os.RemoveAll(originalPath); err != nil {
-				return err
+				return 0, err
 			}
 		} else {
 			// If path exits we almost always just want to remove and replace it.
@@ -107,7 +100,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			if fi, err := os.Lstat(path); err == nil {
 				if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
 					if err := os.RemoveAll(path); err != nil {
-						return err
+						return 0, err
 					}
 				}
 			}
@@ -122,18 +115,18 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 				linkBasename := filepath.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
-					return fmt.Errorf("Invalid aufs hardlink")
+					return 0, fmt.Errorf("Invalid aufs hardlink")
 				}
 				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
 				if err != nil {
-					return err
+					return 0, err
 				}
 				defer tmpFile.Close()
 				srcData = tmpFile
 			}
 
 			if err := createTarFile(path, dest, srcHdr, srcData, true); err != nil {
-				return err
+				return 0, err
 			}
 
 			// Directory mtimes must be handled at the end to avoid further
@@ -148,9 +141,29 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 		path := filepath.Join(dest, hdr.Name)
 		ts := []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
 		if err := syscall.UtimesNano(path, ts); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	return nil
+	return size, nil
+}
+
+// ApplyLayer parses a diff in the standard layer format from `layer`, and
+// applies it to the directory `dest`. Returns the size in bytes of the
+// contents of the layer.
+func ApplyLayer(dest string, layer ArchiveReader) (int64, error) {
+	dest = filepath.Clean(dest)
+
+	// We need to be able to set any perms
+	oldmask, err := system.Umask(0)
+	if err != nil {
+		return 0, err
+	}
+	defer system.Umask(oldmask) // ignore err, ErrNotSupportedPlatform
+
+	layer, err = DecompressStream(layer)
+	if err != nil {
+		return 0, err
+	}
+	return UnpackLayer(dest, layer)
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff_test.go
@@ -1,0 +1,191 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+)
+
+func TestApplyLayerInvalidFilenames(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{
+			{
+				Name:     "../victim/dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{
+			{
+				// Note the leading slash
+				Name:     "/../victim/slash-dotdot",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidFilenames", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestApplyLayerInvalidHardlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeLink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (hardlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try reading victim/hello (hardlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // Try removing victim directory (hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeLink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidHardlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
+func TestApplyLayerInvalidSymlink(t *testing.T) {
+	for i, headers := range [][]*tar.Header{
+		{ // try reading victim/hello (../)
+			{
+				Name:     "dotdot",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (/../)
+			{
+				Name:     "slash-dotdot",
+				Typeflag: tar.TypeSymlink,
+				// Note the leading slash
+				Linkname: "/../victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try writing victim/file
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "symlink",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try reading victim/hello (symlink, hardlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "hardlink",
+				Typeflag: tar.TypeLink,
+				Linkname: "loophole-victim/hello",
+				Mode:     0644,
+			},
+		},
+		{ // try removing victim directory (symlink)
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../victim",
+				Mode:     0755,
+			},
+			{
+				Name:     "loophole-victim",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+		},
+	} {
+		if err := testBreakout("applylayer", "docker-TestApplyLayerInvalidSymlink", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/utils_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/utils_test.go
@@ -1,0 +1,167 @@
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+)
+
+var testUntarFns = map[string]func(string, io.Reader) error{
+	"untar": func(dest string, r io.Reader) error {
+		return Untar(r, dest, nil)
+	},
+	"applylayer": func(dest string, r io.Reader) error {
+		_, err := ApplyLayer(dest, ArchiveReader(r))
+		return err
+	},
+}
+
+// testBreakout is a helper function that, within the provided `tmpdir` directory,
+// creates a `victim` folder with a generated `hello` file in it.
+// `untar` extracts to a directory named `dest`, the tar file created from `headers`.
+//
+// Here are the tested scenarios:
+// - removed `victim` folder				(write)
+// - removed files from `victim` folder			(write)
+// - new files in `victim` folder			(write)
+// - modified files in `victim` folder			(write)
+// - file in `dest` with same content as `victim/hello` (read)
+//
+// When using testBreakout make sure you cover one of the scenarios listed above.
+func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
+	tmpdir, err := ioutil.TempDir("", tmpdir)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	dest := filepath.Join(tmpdir, "dest")
+	if err := os.Mkdir(dest, 0755); err != nil {
+		return err
+	}
+
+	victim := filepath.Join(tmpdir, "victim")
+	if err := os.Mkdir(victim, 0755); err != nil {
+		return err
+	}
+	hello := filepath.Join(victim, "hello")
+	helloData, err := time.Now().MarshalText()
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(hello, helloData, 0644); err != nil {
+		return err
+	}
+	helloStat, err := os.Stat(hello)
+	if err != nil {
+		return err
+	}
+
+	reader, writer := io.Pipe()
+	go func() {
+		t := tar.NewWriter(writer)
+		for _, hdr := range headers {
+			t.WriteHeader(hdr)
+		}
+		t.Close()
+	}()
+
+	untar := testUntarFns[untarFn]
+	if untar == nil {
+		return fmt.Errorf("could not find untar function %q in testUntarFns", untarFn)
+	}
+	if err := untar(dest, reader); err != nil {
+		if _, ok := err.(breakoutError); !ok {
+			// If untar returns an error unrelated to an archive breakout,
+			// then consider this an unexpected error and abort.
+			return err
+		}
+		// Here, untar detected the breakout.
+		// Let's move on verifying that indeed there was no breakout.
+		fmt.Printf("breakoutError: %v\n", err)
+	}
+
+	// Check victim folder
+	f, err := os.Open(victim)
+	if err != nil {
+		// codepath taken if victim folder was removed
+		return fmt.Errorf("archive breakout: error reading %q: %v", victim, err)
+	}
+	defer f.Close()
+
+	// Check contents of victim folder
+	//
+	// We are only interested in getting 2 files from the victim folder, because if all is well
+	// we expect only one result, the `hello` file. If there is a second result, it cannot
+	// hold the same name `hello` and we assume that a new file got created in the victim folder.
+	// That is enough to detect an archive breakout.
+	names, err := f.Readdirnames(2)
+	if err != nil {
+		// codepath taken if victim is not a folder
+		return fmt.Errorf("archive breakout: error reading directory content of %q: %v", victim, err)
+	}
+	for _, name := range names {
+		if name != "hello" {
+			// codepath taken if new file was created in victim folder
+			return fmt.Errorf("archive breakout: new file %q", name)
+		}
+	}
+
+	// Check victim/hello
+	f, err = os.Open(hello)
+	if err != nil {
+		// codepath taken if read permissions were removed
+		return fmt.Errorf("archive breakout: could not lstat %q: %v", hello, err)
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if helloStat.IsDir() != fi.IsDir() ||
+		// TODO: cannot check for fi.ModTime() change
+		helloStat.Mode() != fi.Mode() ||
+		helloStat.Size() != fi.Size() ||
+		!bytes.Equal(helloData, b) {
+		// codepath taken if hello has been modified
+		return fmt.Errorf("archive breakout: file %q has been modified. Contents: expected=%q, got=%q. FileInfo: expected=%#v, got=%#v.", hello, helloData, b, helloStat, fi)
+	}
+
+	// Check that nothing in dest/ has the same content as victim/hello.
+	// Since victim/hello was generated with time.Now(), it is safe to assume
+	// that any file whose content matches exactly victim/hello, managed somehow
+	// to access victim/hello.
+	return filepath.Walk(dest, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			if err != nil {
+				// skip directory if error
+				return filepath.SkipDir
+			}
+			// enter directory
+			return nil
+		}
+		if err != nil {
+			// skip file if error
+			return nil
+		}
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			// Houston, we have a problem. Aborting (space)walk.
+			return err
+		}
+		if bytes.Equal(helloData, b) {
+			return fmt.Errorf("archive breakout: file %q has been accessed via %q", hello, path)
+		}
+		return nil
+	})
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+func Lstat(path string) (*Stat, error) {
+	s := &syscall.Stat_t{}
+	err := syscall.Lstat(path, s)
+	if err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_test.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLstat(t *testing.T) {
+	file, invalid, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	statFile, err := Lstat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statFile == nil {
+		t.Fatal("returned empty stat for existing file")
+	}
+
+	statInvalid, err := Lstat(invalid)
+	if err == nil {
+		t.Fatal("did not return error for non-existing file")
+	}
+	if statInvalid != nil {
+		t.Fatal("returned non-nil stat for non-existing file")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package system
+
+func Lstat(path string) (*Stat, error) {
+	// should not be called on cli code path
+	return nil, ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+func Mknod(path string, mode uint32, dev int) error {
+	return syscall.Mknod(path, mode, dev)
+}
+
+// Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
+// They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
+// then the top 12 bits of the minor
+func Mkdev(major int64, minor int64) uint32 {
+	return uint32(((minor & 0xfff00) << 12) | ((major & 0xfff) << 8) | (minor & 0xff))
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/mknod_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package system
+
+func Mknod(path string, mode uint32, dev int) error {
+	// should not be called on cli code path
+	return ErrNotSupportedPlatform
+}
+
+func Mkdev(major int64, minor int64) uint32 {
+	panic("Mkdev not implemented on windows, should not be called on cli code")
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat.go
@@ -1,0 +1,42 @@
+package system
+
+import (
+	"syscall"
+)
+
+type Stat struct {
+	mode uint32
+	uid  uint32
+	gid  uint32
+	rdev uint64
+	size int64
+	mtim syscall.Timespec
+}
+
+func (s Stat) Mode() uint32 {
+	return s.mode
+}
+
+func (s Stat) Uid() uint32 {
+	return s.uid
+}
+
+func (s Stat) Gid() uint32 {
+	return s.gid
+}
+
+func (s Stat) Rdev() uint64 {
+	return s.rdev
+}
+
+func (s Stat) Size() int64 {
+	return s.size
+}
+
+func (s Stat) Mtim() syscall.Timespec {
+	return s.mtim
+}
+
+func (s Stat) GetLastModification() syscall.Timespec {
+	return s.Mtim()
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_linux.go
@@ -4,10 +4,11 @@ import (
 	"syscall"
 )
 
-func GetLastAccess(stat *syscall.Stat_t) syscall.Timespec {
-	return stat.Atim
-}
-
-func GetLastModification(stat *syscall.Stat_t) syscall.Timespec {
-	return stat.Mtim
+func fromStatT(s *syscall.Stat_t) (*Stat, error) {
+	return &Stat{size: s.Size,
+		mode: s.Mode,
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: s.Rdev,
+		mtim: s.Mtim}, nil
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_test.go
@@ -1,0 +1,36 @@
+package system
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestFromStatT(t *testing.T) {
+	file, _, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
+
+	stat := &syscall.Stat_t{}
+	err := syscall.Lstat(file, stat)
+
+	s, err := fromStatT(stat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stat.Mode != s.Mode() {
+		t.Fatal("got invalid mode")
+	}
+	if stat.Uid != s.Uid() {
+		t.Fatal("got invalid uid")
+	}
+	if stat.Gid != s.Gid() {
+		t.Fatal("got invalid gid")
+	}
+	if stat.Rdev != s.Rdev() {
+		t.Fatal("got invalid rdev")
+	}
+	if stat.Mtim != s.Mtim() {
+		t.Fatal("got invalid mtim")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_unsupported.go
@@ -1,13 +1,16 @@
-// +build !linux
+// +build !linux,!windows
 
 package system
 
-import "syscall"
+import (
+	"syscall"
+)
 
-func GetLastAccess(stat *syscall.Stat_t) syscall.Timespec {
-	return stat.Atimespec
-}
-
-func GetLastModification(stat *syscall.Stat_t) syscall.Timespec {
-	return stat.Mtimespec
+func fromStatT(s *syscall.Stat_t) (*Stat, error) {
+	return &Stat{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
 }

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/stat_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package system
+
+import (
+	"errors"
+	"syscall"
+)
+
+func fromStatT(s *syscall.Win32FileAttributeData) (*Stat, error) {
+	return nil, errors.New("fromStatT should not be called on windows path")
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package system
+
+import (
+	"syscall"
+)
+
+func Umask(newmask int) (oldmask int, err error) {
+	return syscall.Umask(newmask), nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/umask_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package system
+
+func Umask(newmask int) (oldmask int, err error) {
+	// should not be called on cli code path
+	return 0, ErrNotSupportedPlatform
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/system/utimes_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func prepareFiles(t *testing.T) (string, string, string) {
+func prepareFiles(t *testing.T) (string, string, string, string) {
 	dir, err := ioutil.TempDir("", "docker-system-test")
 	if err != nil {
 		t.Fatal(err)
@@ -26,11 +26,12 @@ func prepareFiles(t *testing.T) (string, string, string) {
 		t.Fatal(err)
 	}
 
-	return file, invalid, symlink
+	return file, invalid, symlink, dir
 }
 
 func TestLUtimesNano(t *testing.T) {
-	file, invalid, symlink := prepareFiles(t)
+	file, invalid, symlink, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
 
 	before, err := os.Stat(file)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size.go
@@ -39,7 +39,7 @@ var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB",
 
 // HumanSize returns a human-readable approximation of a size
 // using SI standard (eg. "44kB", "17MB")
-func HumanSize(size int64) string {
+func HumanSize(size float64) string {
 	return intToString(float64(size), 1000.0, decimapAbbrs)
 }
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/units/size_test.go
@@ -23,9 +23,9 @@ func TestHumanSize(t *testing.T) {
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(3.42*GB))
-	assertEquals(t, "5.372 TB", HumanSize(5.372*TB))
-	assertEquals(t, "2.22 PB", HumanSize(2.22*PB))
+	assertEquals(t, "3.42 GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.372 TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.22 PB", HumanSize(float64(2.22*PB)))
 }
 
 func TestFromHumanSize(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.2.2
   - 1.3.1
+  - 1.4
   - tip
 env:
   - GOARCH=amd64
@@ -10,3 +11,4 @@ install:
   - go get -d ./...
 script:
   - go test ./...
+  - ./testing/bin/fmtpolice

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
@@ -3,8 +3,11 @@
 Aldrin Leal <aldrin@leal.eng.br>
 Andreas Jaekle <andreas@jaekle.net>
 Andrews Medina <andrewsmedina@gmail.com>
+Artem Sidorenko <artem@2realities.com>
 Andy Goldstein <andy.goldstein@redhat.com>
 Ben McCann <benmccann.com>
+Brian Lalor <blalor@bravo5.org>
+Burke Libbey <burke@libbey.me>
 Carlos Diaz-Padron <cpadron@mozilla.com>
 Cezar Sa Espinola <cezar.sa@corp.globo.com>
 Cheah Chu Yeow <chuyeow@gmail.com>
@@ -12,27 +15,37 @@ cheneydeng <cheneydeng@qq.com>
 CMGS <ilskdw@gmail.com>
 Daniel, Dao Quang Minh <dqminh89@gmail.com>
 David Huie <dahuie@gmail.com>
+Dawn Chen <dawnchen@google.com>
 Ed <edrocksit@gmail.com>
 Eric Anderson <anderson@copperegg.com>
 Fabio Rehm <fgrehm@gmail.com>
+ Fatih Arslan <ftharsln@gmail.com>
 Flavia Missi <flaviamissi@gmail.com>
 Francisco Souza <f@souza.cc>
 Jari Kolehmainen <jari.kolehmainen@digia.com>
 Jason Wilder <jwilder@litl.com>
+Jawher Moussa <jawher.moussa@gmail.com>
 Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 Jeff Mitchell <jeffrey.mitchell@gmail.com>
 Jeffrey Hulten <jhulten@gmail.com>
 Johan Euphrosine <proppy@google.com>
+Kamil Domanski <kamil@domanski.co>
 Karan Misra <kidoman@gmail.com>
 Kim, Hirokuni <hirokuni.kim@kvh.co.jp>
 Lucas Clemente <lucas@clemente.io>
+Mantas Matelis <mmatelis@coursera.org>
+Martin Sweeney <martin@sweeney.io>
 Máximo Cuadros Ortiz <mcuadros@gmail.com>
+Michal Fojtik <mfojtik@redhat.com>
 Mike Dillon <mike.dillon@synctree.com>
+Mrunal Patel <mrunalp@gmail.com>
+Nick Ethier <ncethier@gmail.com>
 Omeid Matten <public@omeid.me>
 Paul Morie <pmorie@gmail.com>
 Peter Jihoon Kim <raingrove@gmail.com>
 Philippe Lafoucrière <philippe.lafoucriere@tech-angels.com>
-Rafe Colton <r.colton@modcloth.com>
+Rafe Colton <rafael.colton@gmail.com>
+Rob Miller <rob@kalistra.com>
 Robert Williamson <williamson.robert@gmail.com>
 Salvador Gironès <salvadorgirones@gmail.com>
 Simon Eskildsen <sirup@sirupsen.com>
@@ -44,3 +57,5 @@ Summer Mousa <smousa@zenoss.com>
 Tarsis Azevedo <tarsis@corp.globo.com>
 Tim Schindler <tim@catalyst-zero.com>
 Wiliam Souza <wiliamsouza83@gmail.com>
+Ye Yin <eyniy@qq.com>
+Yuriy Bogdanov <chinsay@gmail.com>

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/README.markdown
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/README.markdown
@@ -22,14 +22,14 @@ import (
 func main() {
         endpoint := "unix:///var/run/docker.sock"
         client, _ := docker.NewClient(endpoint)
-        imgs, _ := client.ListImages(true)
+        imgs, _ := client.ListImages(docker.ListImagesOptions{All: false})
         for _, img := range imgs {
                 fmt.Println("ID: ", img.ID)
                 fmt.Println("RepoTags: ", img.RepoTags)
                 fmt.Println("Created: ", img.Created)
                 fmt.Println("Size: ", img.Size)
                 fmt.Println("VirtualSize: ", img.VirtualSize)
-                fmt.Println("ParentId: ", img.ParentId)
+                fmt.Println("ParentId: ", img.ParentID)
         }
 }
 ```

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/change.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/change.go
@@ -6,11 +6,18 @@ package docker
 
 import "fmt"
 
+// ChangeType is a type for constants indicating the type of change
+// in a container
 type ChangeType int
 
 const (
+	// ChangeModify is the ChangeType for container modifications
 	ChangeModify ChangeType = iota
+
+	// ChangeAdd is the ChangeType for additions to a container
 	ChangeAdd
+
+	// ChangeDelete is the ChangeType for deletions from a container
 	ChangeDelete
 )
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client_test.go
@@ -39,8 +39,8 @@ func TestNewAPIClient(t *testing.T) {
 	if !client.SkipServerVersionCheck {
 		t.Error("Expected SkipServerVersionCheck to be true, got false")
 	}
-	if client.requestedApiVersion != nil {
-		t.Errorf("Expected requestedApiVersion to be nil, got %#v.", client.requestedApiVersion)
+	if client.requestedAPIVersion != nil {
+		t.Errorf("Expected requestedAPIVersion to be nil, got %#v.", client.requestedAPIVersion)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestNewTSLAPIClient(t *testing.T) {
 	if !client.SkipServerVersionCheck {
 		t.Error("Expected SkipServerVersionCheck to be true, got false")
 	}
-	if client.requestedApiVersion != nil {
-		t.Errorf("Expected requestedApiVersion to be nil, got %#v.", client.requestedApiVersion)
+	if client.requestedAPIVersion != nil {
+		t.Errorf("Expected requestedAPIVersion to be nil, got %#v.", client.requestedAPIVersion)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestNewVersionedClient(t *testing.T) {
 	if client.HTTPClient != http.DefaultClient {
 		t.Errorf("Expected http.Client %#v. Got %#v.", http.DefaultClient, client.HTTPClient)
 	}
-	if reqVersion := client.requestedApiVersion.String(); reqVersion != "1.12" {
-		t.Errorf("Wrong requestApiVersion. Want %q. Got %q.", "1.12", reqVersion)
+	if reqVersion := client.requestedAPIVersion.String(); reqVersion != "1.12" {
+		t.Errorf("Wrong requestAPIVersion. Want %q. Got %q.", "1.12", reqVersion)
 	}
 	if client.SkipServerVersionCheck {
 		t.Error("Expected SkipServerVersionCheck to be false, got true")
@@ -93,15 +93,15 @@ func TestNewTLSVersionedClient(t *testing.T) {
 	keyPath := "testing/data/key.pem"
 	caPath := "testing/data/ca.pem"
 	endpoint := "https://localhost:4243"
-	client, err := NewVersionnedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	client, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if client.endpoint != endpoint {
 		t.Errorf("Expected endpoint %s. Got %s.", endpoint, client.endpoint)
 	}
-	if reqVersion := client.requestedApiVersion.String(); reqVersion != "1.14" {
-		t.Errorf("Wrong requestApiVersion. Want %q. Got %q.", "1.14", reqVersion)
+	if reqVersion := client.requestedAPIVersion.String(); reqVersion != "1.14" {
+		t.Errorf("Wrong requestAPIVersion. Want %q. Got %q.", "1.14", reqVersion)
 	}
 	if client.SkipServerVersionCheck {
 		t.Error("Expected SkipServerVersionCheck to be false, got true")
@@ -113,7 +113,7 @@ func TestNewTLSVersionedClientInvalidCA(t *testing.T) {
 	keyPath := "testing/data/key.pem"
 	caPath := "testing/data/key.pem"
 	endpoint := "https://localhost:4243"
-	_, err := NewVersionnedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
+	_, err := NewVersionedTLSClient(endpoint, certPath, keyPath, caPath, "1.14")
 	if err == nil {
 		t.Errorf("Expected invalid ca at %s", caPath)
 	}
@@ -206,6 +206,7 @@ func TestQueryString(t *testing.T) {
 		{ListContainersOptions{All: true}, "all=1"},
 		{ListContainersOptions{Before: "something"}, "before=something"},
 		{ListContainersOptions{Before: "something", Since: "other"}, "before=something&since=other"},
+		{ListContainersOptions{Filters: map[string][]string{"status": {"paused", "running"}}}, "filters=%7B%22status%22%3A%5B%22paused%22%2C%22running%22%5D%7D"},
 		{dumb{X: 10, Y: 10.35000}, "x=10&y=10.35"},
 		{dumb{W: v, X: 10, Y: 10.35000}, f32QueryString},
 		{dumb{X: 10, Y: 10.35000, Z: 10}, "x=10&y=10.35&zee=10"},
@@ -224,7 +225,7 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
-func TestNewApiVersionFailures(t *testing.T) {
+func TestNewAPIVersionFailures(t *testing.T) {
 	var tests = []struct {
 		input         string
 		expectedError string
@@ -233,17 +234,17 @@ func TestNewApiVersionFailures(t *testing.T) {
 		{"1.0-beta", `Unable to parse version "1.0-beta": "0-beta" is not an integer`},
 	}
 	for _, tt := range tests {
-		v, err := NewApiVersion(tt.input)
+		v, err := NewAPIVersion(tt.input)
 		if v != nil {
 			t.Errorf("Expected <nil> version, got %v.", v)
 		}
 		if err.Error() != tt.expectedError {
-			t.Errorf("NewApiVersion(%q): wrong error. Want %q. Got %q", tt.input, tt.expectedError, err.Error())
+			t.Errorf("NewAPIVersion(%q): wrong error. Want %q. Got %q", tt.input, tt.expectedError, err.Error())
 		}
 	}
 }
 
-func TestApiVersions(t *testing.T) {
+func TestAPIVersions(t *testing.T) {
 	var tests = []struct {
 		a                              string
 		b                              string
@@ -269,8 +270,8 @@ func TestApiVersions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		a, _ := NewApiVersion(tt.a)
-		b, _ := NewApiVersion(tt.b)
+		a, _ := NewAPIVersion(tt.a)
+		b, _ := NewAPIVersion(tt.b)
 
 		if tt.expectedALessThanB && !a.LessThan(b) {
 			t.Errorf("Expected %#v < %#v", a, b)

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
@@ -18,15 +18,17 @@ import (
 
 // ListContainersOptions specify parameters to the ListContainers function.
 //
-// See http://goo.gl/XqtcyU for more details.
+// See http://goo.gl/6Y4Gz7 for more details.
 type ListContainersOptions struct {
-	All    bool
-	Size   bool
-	Limit  int
-	Since  string
-	Before string
+	All     bool
+	Size    bool
+	Limit   int
+	Since   string
+	Before  string
+	Filters map[string][]string
 }
 
+// APIPort is a type that represents a port mapping returned by the Docker API
 type APIPort struct {
 	PrivatePort int64  `json:"PrivatePort,omitempty" yaml:"PrivatePort,omitempty"`
 	PublicPort  int64  `json:"PublicPort,omitempty" yaml:"PublicPort,omitempty"`
@@ -51,7 +53,7 @@ type APIContainers struct {
 
 // ListContainers returns a slice of containers matching the given criteria.
 //
-// See http://goo.gl/XqtcyU for more details.
+// See http://goo.gl/6Y4Gz7 for more details.
 func (c *Client) ListContainers(opts ListContainersOptions) ([]APIContainers, error) {
 	path := "/containers/json?" + queryString(opts)
 	body, _, err := c.do("GET", path, nil)
@@ -88,8 +90,10 @@ func (p Port) Proto() string {
 type State struct {
 	Running    bool      `json:"Running,omitempty" yaml:"Running,omitempty"`
 	Paused     bool      `json:"Paused,omitempty" yaml:"Paused,omitempty"`
+	OOMKilled  bool      `json:"OOMKilled,omitempty" yaml:"OOMKilled,omitempty"`
 	Pid        int       `json:"Pid,omitempty" yaml:"Pid,omitempty"`
 	ExitCode   int       `json:"ExitCode,omitempty" yaml:"ExitCode,omitempty"`
+	Error      string    `json:"Error,omitempty" yaml:"Error,omitempty"`
 	StartedAt  time.Time `json:"StartedAt,omitempty" yaml:"StartedAt,omitempty"`
 	FinishedAt time.Time `json:"FinishedAt,omitempty" yaml:"FinishedAt,omitempty"`
 }
@@ -105,13 +109,18 @@ func (s *State) String() string {
 	return fmt.Sprintf("Exit %d", s.ExitCode)
 }
 
+// PortBinding represents the host/container port mapping as returned in the
+// `docker inspect` json
 type PortBinding struct {
-	HostIp   string `json:"HostIP,omitempty" yaml:"HostIP,omitempty"`
+	HostIP   string `json:"HostIP,omitempty" yaml:"HostIP,omitempty"`
 	HostPort string `json:"HostPort,omitempty" yaml:"HostPort,omitempty"`
 }
 
+// PortMapping represents a deprecated field in the `docker inspect` output,
+// and its value as found in NetworkSettings should always be nil
 type PortMapping map[string]string
 
+// NetworkSettings contains network-related information about a container
 type NetworkSettings struct {
 	IPAddress   string                 `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
 	IPPrefixLen int                    `json:"IPPrefixLen,omitempty" yaml:"IPPrefixLen,omitempty"`
@@ -121,6 +130,8 @@ type NetworkSettings struct {
 	Ports       map[Port][]PortBinding `json:"Ports,omitempty" yaml:"Ports,omitempty"`
 }
 
+// PortMappingAPI translates the port mappings as contained in NetworkSettings
+// into the format in which they would appear when returned by the API
 func (settings *NetworkSettings) PortMappingAPI() []APIPort {
 	var mapping []APIPort
 	for port, bindings := range settings.Ports {
@@ -139,7 +150,7 @@ func (settings *NetworkSettings) PortMappingAPI() []APIPort {
 				PrivatePort: int64(p),
 				PublicPort:  int64(h),
 				Type:        port.Proto(),
-				IP:          binding.HostIp,
+				IP:          binding.HostIP,
 			})
 		}
 	}
@@ -154,14 +165,17 @@ func parsePort(rawPort string) (int, error) {
 	return int(port), nil
 }
 
+// Config is the list of configuration options used when creating a container.
+// Config does not the options that are specific to starting a container on a
+// given host.  Those are contained in HostConfig
 type Config struct {
 	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
 	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
 	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
 	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
 	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	CpuShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CpuSet          string              `json:"CpuSet,omitempty" yaml:"CpuSet,omitempty"`
+	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
+	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
 	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
 	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
 	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
@@ -172,15 +186,19 @@ type Config struct {
 	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
 	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
 	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
-	Dns             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
+	DNS             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
 	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
 	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
 	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
 	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
 	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
 	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	SecurityOpts    []string            `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty"`
+	OnBuild         []string            `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty"`
 }
 
+// Container is the type encompasing everything about a container - its config,
+// hostconfig, etc.
 type Container struct {
 	ID string `json:"Id" yaml:"Id"`
 
@@ -249,10 +267,11 @@ func (c *Client) ContainerChanges(id string) ([]Change, error) {
 
 // CreateContainerOptions specify parameters to the CreateContainer function.
 //
-// See http://goo.gl/mErxNp for more details.
+// See http://goo.gl/2xxQQK for more details.
 type CreateContainerOptions struct {
-	Name   string
-	Config *Config `qs:"-"`
+	Name       string
+	Config     *Config `qs:"-"`
+	HostConfig *HostConfig
 }
 
 // CreateContainer creates a new container, returning the container instance,
@@ -261,7 +280,14 @@ type CreateContainerOptions struct {
 // See http://goo.gl/mErxNp for more details.
 func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error) {
 	path := "/containers/create?" + queryString(opts)
-	body, status, err := c.do("POST", path, opts.Config)
+	body, status, err := c.do("POST", path, struct {
+		*Config
+		HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+	}{
+		opts.Config,
+		opts.HostConfig,
+	})
+
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}
@@ -279,6 +305,8 @@ func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error
 	return &container, nil
 }
 
+// KeyValuePair is a type for generic key/value pairs as used in the Lxc
+// configuration
 type KeyValuePair struct {
 	Key   string `json:"Key,omitempty" yaml:"Key,omitempty"`
 	Value string `json:"Value,omitempty" yaml:"Value,omitempty"`
@@ -315,6 +343,8 @@ func NeverRestart() RestartPolicy {
 	return RestartPolicy{Name: "no"}
 }
 
+// HostConfig contains the container options related to starting a container on
+// a given host
 type HostConfig struct {
 	Binds           []string               `json:"Binds,omitempty" yaml:"Binds,omitempty"`
 	CapAdd          []string               `json:"CapAdd,omitempty" yaml:"CapAdd,omitempty"`
@@ -325,11 +355,12 @@ type HostConfig struct {
 	PortBindings    map[Port][]PortBinding `json:"PortBindings,omitempty" yaml:"PortBindings,omitempty"`
 	Links           []string               `json:"Links,omitempty" yaml:"Links,omitempty"`
 	PublishAllPorts bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty"`
-	Dns             []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
-	DnsSearch       []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
+	DNS             []string               `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.10 and above only
+	DNSSearch       []string               `json:"DnsSearch,omitempty" yaml:"DnsSearch,omitempty"`
 	ExtraHosts      []string               `json:"ExtraHosts,omitempty" yaml:"ExtraHosts,omitempty"`
 	VolumesFrom     []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
 	NetworkMode     string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
+	IpcMode         string                 `json:"IpcMode,omitempty" yaml:"IpcMode,omitempty"`
 	RestartPolicy   RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`
 }
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go
@@ -50,6 +50,11 @@ var (
 	// ErrListenerAlreadyExists is the error returned when the listerner already
 	// exists.
 	ErrListenerAlreadyExists = errors.New("listener already exists for docker events")
+
+	// EOFEvent is sent when the event listener receives an EOF error.
+	EOFEvent = &APIEvents{
+		Status: "EOF",
+	}
 )
 
 // AddEventListener adds a new listener to container events in the Docker API.
@@ -112,6 +117,16 @@ func (eventState *eventMonitoringState) removeListener(listener chan<- *APIEvent
 	return nil
 }
 
+func (eventState *eventMonitoringState) closeListeners() {
+	eventState.Lock()
+	defer eventState.Unlock()
+	for _, l := range eventState.listeners {
+		close(l)
+		eventState.Add(-1)
+	}
+	eventState.listeners = nil
+}
+
 func listenerExists(a chan<- *APIEvents, list *[]chan<- *APIEvents) bool {
 	for _, b := range *list {
 		if b == a {
@@ -153,7 +168,7 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if err = eventState.connectWithRetry(c); err != nil {
-		eventState.terminate(err)
+		eventState.terminate()
 	}
 	for eventState.isEnabled() {
 		timeout := time.After(100 * time.Millisecond)
@@ -162,11 +177,16 @@ func (eventState *eventMonitoringState) monitorEvents(c *Client) {
 			if !ok {
 				return
 			}
+			if ev == EOFEvent {
+				eventState.closeListeners()
+				eventState.terminate()
+				return
+			}
+			eventState.updateLastSeen(ev)
 			go eventState.sendEvent(ev)
-			go eventState.updateLastSeen(ev)
 		case err = <-eventState.errC:
 			if err == ErrNoListeners {
-				eventState.terminate(nil)
+				eventState.terminate()
 				return
 			} else if err != nil {
 				defer func() { go eventState.monitorEvents(c) }()
@@ -207,7 +227,7 @@ func (eventState *eventMonitoringState) sendEvent(event *APIEvents) {
 	eventState.Add(1)
 	defer eventState.Done()
 	if eventState.isEnabled() {
-		if eventState.noListeners() {
+		if len(eventState.listeners) == 0 {
 			eventState.errC <- ErrNoListeners
 			return
 		}
@@ -226,7 +246,7 @@ func (eventState *eventMonitoringState) updateLastSeen(e *APIEvents) {
 	}
 }
 
-func (eventState *eventMonitoringState) terminate(err error) {
+func (eventState *eventMonitoringState) terminate() {
 	eventState.disableEventMonitoring()
 }
 
@@ -268,6 +288,10 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			var event APIEvents
 			if err = decoder.Decode(&event); err != nil {
 				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					if c.eventMonitor.isEnabled() {
+						// Signal that we're exiting.
+						eventChan <- EOFEvent
+					}
 					break
 				}
 				errChan <- err
@@ -278,7 +302,7 @@ func (c *Client) eventHijack(startTime int64, eventChan chan *APIEvents, errChan
 			if !c.eventMonitor.isEnabled() {
 				return
 			}
-			c.eventMonitor.C <- &event
+			eventChan <- &event
 		}
 	}(res, conn)
 	return nil

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event_test.go
@@ -89,7 +89,7 @@ func testEventListeners(testName string, t *testing.T, buildServer func(http.Han
 	for {
 		select {
 		case msg := <-listener:
-			t.Logf("Recieved: %s", *msg)
+			t.Logf("Received: %s", *msg)
 			count++
 			err = checkEvent(count, msg)
 			if err != nil {

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestExecCreate(t *testing.T) {
 	jsonContainer := `{"Id": "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"}`
-	var expected struct{ Id string }
+	var expected struct{ ID string }
 	err := json.Unmarshal([]byte(jsonContainer), &expected)
 	if err != nil {
 		t.Fatal(err)
@@ -35,9 +36,9 @@ func TestExecCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedId := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
-	if execObj.Id != expectedId {
-		t.Errorf("ExecCreate: wrong ID. Want %q. Got %q.", expectedId, execObj.Id)
+	expectedID := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	if execObj.ID != expectedID {
+		t.Errorf("ExecCreate: wrong ID. Want %q. Got %q.", expectedID, execObj.ID)
 	}
 	req := fakeRT.requests[0]
 	if req.Method != "POST" {
@@ -47,7 +48,7 @@ func TestExecCreate(t *testing.T) {
 	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
 		t.Errorf("ExecCreate: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
 	}
-	var gotBody struct{ Id string }
+	var gotBody struct{ ID string }
 	err = json.NewDecoder(req.Body).Decode(&gotBody)
 	if err != nil {
 		t.Fatal(err)
@@ -55,13 +56,13 @@ func TestExecCreate(t *testing.T) {
 }
 
 func TestExecStartDetached(t *testing.T) {
-	execId := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	execID := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	fakeRT := &FakeRoundTripper{status: http.StatusOK}
 	client := newTestClient(fakeRT)
 	config := StartExecOptions{
 		Detach: true,
 	}
-	err := client.StartExec(execId, config)
+	err := client.StartExec(execID, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestExecStartDetached(t *testing.T) {
 	if req.Method != "POST" {
 		t.Errorf("ExecStart: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
 	}
-	expectedURL, _ := url.Parse(client.getURL("/exec/" + execId + "/start"))
+	expectedURL, _ := url.Parse(client.getURL("/exec/" + execID + "/start"))
 	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
 		t.Errorf("ExecCreate: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
 	}
@@ -97,7 +98,7 @@ func TestExecStartAndAttach(t *testing.T) {
 	client.SkipServerVersionCheck = true
 	var stdout, stderr bytes.Buffer
 	success := make(chan struct{})
-	execId := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	execID := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	opts := StartExecOptions{
 		OutputStream: &stdout,
 		ErrorStream:  &stderr,
@@ -105,15 +106,15 @@ func TestExecStartAndAttach(t *testing.T) {
 		RawTerminal:  true,
 		Success:      success,
 	}
-	go client.StartExec(execId, opts)
+	go client.StartExec(execID, opts)
 	<-success
 }
 
 func TestExecResize(t *testing.T) {
-	execId := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
+	execID := "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2"
 	fakeRT := &FakeRoundTripper{status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	err := client.ResizeExecTTY(execId, 10, 20)
+	err := client.ResizeExecTTY(execID, 10, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,8 +122,138 @@ func TestExecResize(t *testing.T) {
 	if req.Method != "POST" {
 		t.Errorf("ExecStart: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
 	}
-	expectedURL, _ := url.Parse(client.getURL("/exec/" + execId + "/resize?h=10&w=20"))
+	expectedURL, _ := url.Parse(client.getURL("/exec/" + execID + "/resize?h=10&w=20"))
 	if gotPath := req.URL.RequestURI(); gotPath != expectedURL.RequestURI() {
 		t.Errorf("ExecCreate: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
+	}
+}
+
+func TestExecInspect(t *testing.T) {
+	jsonExec := `{
+	  "ID": "32adfeeec34250f9530ce1dafd40c6233832315e065ea6b362d745e2f63cde0e",
+	  "Running": true,
+	  "ExitCode": 0,
+	  "ProcessConfig": {
+	    "privileged": false,
+	    "user": "",
+	    "tty": true,
+	    "entrypoint": "bash",
+	    "arguments": []
+	  },
+	  "OpenStdin": true,
+	  "OpenStderr": true,
+	  "OpenStdout": true,
+	  "Container": {
+	    "State": {
+	      "Running": true,
+	      "Paused": false,
+	      "Restarting": false,
+	      "OOMKilled": false,
+	      "Pid": 29392,
+	      "ExitCode": 0,
+	      "Error": "",
+	      "StartedAt": "2015-01-21T17:08:59.634662178Z",
+	      "FinishedAt": "0001-01-01T00:00:00Z"
+	    },
+	    "ID": "922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521",
+	    "Created": "2015-01-21T17:08:59.46407212Z",
+	    "Path": "/bin/bash",
+	    "Args": [
+	      "-lc",
+	      "tsuru_unit_agent http://192.168.50.4:8080 689b30e0ab3adce374346de2e72512138e0e8b75 gtest /var/lib/tsuru/start && tail -f /dev/null"
+	    ],
+	    "Config": {
+	      "Hostname": "922cd0568714",
+	      "Domainname": "",
+	      "User": "ubuntu",
+	      "Memory": 0,
+	      "MemorySwap": 0,
+	      "CpuShares": 100,
+	      "Cpuset": "",
+	      "AttachStdin": false,
+	      "AttachStdout": false,
+	      "AttachStderr": false,
+	      "PortSpecs": null,
+	      "ExposedPorts": {
+	        "8888/tcp": {}
+	      },
+	      "Tty": false,
+	      "OpenStdin": false,
+	      "StdinOnce": false,
+	      "Env": [
+	        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	      ],
+	      "Cmd": [
+	        "/bin/bash",
+	        "-lc",
+	        "tsuru_unit_agent http://192.168.50.4:8080 689b30e0ab3adce374346de2e72512138e0e8b75 gtest /var/lib/tsuru/start && tail -f /dev/null"
+	      ],
+	      "Image": "tsuru/app-gtest",
+	      "Volumes": null,
+	      "WorkingDir": "",
+	      "Entrypoint": null,
+	      "NetworkDisabled": false,
+	      "MacAddress": "",
+	      "OnBuild": null
+	    },
+	    "Image": "a88060b8b54fde0f7168c86742d0ce83b80f3f10925d85c98fdad9ed00bef544",
+	    "NetworkSettings": {
+	      "IPAddress": "172.17.0.8",
+	      "IPPrefixLen": 16,
+	      "MacAddress": "02:42:ac:11:00:08",
+	      "LinkLocalIPv6Address": "fe80::42:acff:fe11:8",
+	      "LinkLocalIPv6PrefixLen": 64,
+	      "GlobalIPv6Address": "",
+	      "GlobalIPv6PrefixLen": 0,
+	      "Gateway": "172.17.42.1",
+	      "IPv6Gateway": "",
+	      "Bridge": "docker0",
+	      "PortMapping": null,
+	      "Ports": {
+	        "8888/tcp": [
+	          {
+	            "HostIp": "0.0.0.0",
+	            "HostPort": "49156"
+	          }
+	        ]
+	      }
+	    },
+	    "ResolvConfPath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/resolv.conf",
+	    "HostnamePath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/hostname",
+	    "HostsPath": "/var/lib/docker/containers/922cd0568714763dc725b24b7c9801016b2a3de68e2a1dc989bf5abf07740521/hosts",
+	    "Name": "/c7e43b72288ee9d0270a",
+	    "Driver": "aufs",
+	    "ExecDriver": "native-0.2",
+	    "MountLabel": "",
+	    "ProcessLabel": "",
+	    "AppArmorProfile": "",
+	    "RestartCount": 0,
+	    "UpdateDns": false,
+	    "Volumes": {},
+	    "VolumesRW": {}
+	  }
+	}`
+	var expected ExecInspect
+	err := json.Unmarshal([]byte(jsonExec), &expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRT := &FakeRoundTripper{message: jsonExec, status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	expectedID := "32adfeeec34250f9530ce1dafd40c6233832315e065ea6b362d745e2f63cde0e"
+	execObj, err := client.InspectExec(expectedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*execObj, expected) {
+		t.Errorf("ExecInspect: Expected %#v. Got %#v.", expected, *execObj)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "GET" {
+		t.Errorf("ExecInspect: wrong HTTP method. Want %q. Got %q.", "GET", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/exec/" + expectedID + "/json"))
+	if gotPath := fakeRT.requests[0].URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("ExecInspect: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
 	}
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image_test.go
@@ -88,7 +88,7 @@ func TestListImages(t *testing.T) {
 		t.Fatal(err)
 	}
 	client := newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
-	images, err := client.ListImages(false)
+	images, err := client.ListImages(ListImagesOptions{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -100,25 +100,42 @@ func TestListImages(t *testing.T) {
 func TestListImagesParameters(t *testing.T) {
 	fakeRT := &FakeRoundTripper{message: "null", status: http.StatusOK}
 	client := newTestClient(fakeRT)
-	_, err := client.ListImages(false)
+	_, err := client.ListImages(ListImagesOptions{All: false})
 	if err != nil {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
 	if req.Method != "GET" {
-		t.Errorf("ListImages(false: Wrong HTTP method. Want GET. Got %s.", req.Method)
+		t.Errorf("ListImages({All: false}: Wrong HTTP method. Want GET. Got %s.", req.Method)
 	}
-	if all := req.URL.Query().Get("all"); all != "0" {
-		t.Errorf("ListImages(false): Wrong parameter. Want all=0. Got all=%s", all)
+	if all := req.URL.Query().Get("all"); all != "0" && all != "" {
+		t.Errorf("ListImages({All: false}): Wrong parameter. Want all=0 or not present at all. Got all=%s", all)
 	}
 	fakeRT.Reset()
-	_, err = client.ListImages(true)
+	_, err = client.ListImages(ListImagesOptions{All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	req = fakeRT.requests[0]
 	if all := req.URL.Query().Get("all"); all != "1" {
-		t.Errorf("ListImages(true): Wrong parameter. Want all=1. Got all=%s", all)
+		t.Errorf("ListImages({All: true}): Wrong parameter. Want all=1. Got all=%s", all)
+	}
+	fakeRT.Reset()
+	_, err = client.ListImages(ListImagesOptions{Filters: map[string][]string{
+		"dangling": {"true"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = fakeRT.requests[0]
+	body := req.URL.Query().Get("filters")
+	var filters map[string][]string
+	err = json.Unmarshal([]byte(body), &filters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filters["dangling"]) != 1 || filters["dangling"][0] != "true" {
+		t.Errorf("ListImages(dangling=[true]): Wrong filter map. Want dangling=[true], got dangling=%v", filters["dangling"])
 	}
 }
 
@@ -188,6 +205,29 @@ func TestRemoveImageNotFound(t *testing.T) {
 	err := client.RemoveImage("test:")
 	if err != ErrNoSuchImage {
 		t.Errorf("RemoveImage: wrong error. Want %#v. Got %#v.", ErrNoSuchImage, err)
+	}
+}
+
+func TestRemoveImageExtended(t *testing.T) {
+	name := "test"
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusNoContent}
+	client := newTestClient(fakeRT)
+	err := client.RemoveImageExtended(name, RemoveImageOptions{Force: true, NoPrune: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	expectedMethod := "DELETE"
+	if req.Method != expectedMethod {
+		t.Errorf("RemoveImage(%q): Wrong HTTP method. Want %s. Got %s.", name, expectedMethod, req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/images/" + name))
+	if req.URL.Path != u.Path {
+		t.Errorf("RemoveImage(%q): Wrong request path. Want %q. Got %q.", name, u.Path, req.URL.Path)
+	}
+	expectedQuery := "force=1&noprune=1"
+	if query := req.URL.Query().Encode(); query != expectedQuery {
+		t.Errorf("PushImage: Wrong query string. Want %q. Got %q.", expectedQuery, query)
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tar.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tar.go
@@ -27,9 +27,9 @@ func createTarStream(srcPath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	tarOpts := &archive.TarOptions{
-		Excludes:    excludes,
-		Compression: archive.Uncompressed,
-		NoLchown:    true,
+		ExcludePatterns: excludes,
+		Compression:     archive.Uncompressed,
+		NoLchown:        true,
 	}
 	return archive.TarWithOptions(srcPath, tarOpts)
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server.go
@@ -34,6 +34,7 @@ import (
 // For more details on the remote API, check http://goo.gl/G3plxW.
 type DockerServer struct {
 	containers     []*docker.Container
+	execs          []*docker.ExecInspect
 	cMut           sync.RWMutex
 	images         []docker.Image
 	iMut           sync.RWMutex
@@ -97,12 +98,17 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/containers/{id:.*}/wait").Methods("POST").HandlerFunc(s.handlerWrapper(s.waitContainer))
 	s.mux.Path("/containers/{id:.*}/attach").Methods("POST").HandlerFunc(s.handlerWrapper(s.attachContainer))
 	s.mux.Path("/containers/{id:.*}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.removeContainer))
+	s.mux.Path("/containers/{id:.*}/exec").Methods("POST").HandlerFunc(s.handlerWrapper(s.createExecContainer))
+	s.mux.Path("/exec/{id:.*}/resize").Methods("POST").HandlerFunc(s.handlerWrapper(s.resizeExecContainer))
+	s.mux.Path("/exec/{id:.*}/start").Methods("POST").HandlerFunc(s.handlerWrapper(s.startExecContainer))
+	s.mux.Path("/exec/{id:.*}/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectExecContainer))
 	s.mux.Path("/images/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.pullImage))
 	s.mux.Path("/build").Methods("POST").HandlerFunc(s.handlerWrapper(s.buildImage))
 	s.mux.Path("/images/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.listImages))
 	s.mux.Path("/images/{id:.*}").Methods("DELETE").HandlerFunc(s.handlerWrapper(s.removeImage))
 	s.mux.Path("/images/{name:.*}/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectImage))
 	s.mux.Path("/images/{name:.*}/push").Methods("POST").HandlerFunc(s.handlerWrapper(s.pushImage))
+	s.mux.Path("/images/{name:.*}/tag").Methods("POST").HandlerFunc(s.handlerWrapper(s.tagImage))
 	s.mux.Path("/events").Methods("GET").HandlerFunc(s.listEvents)
 	s.mux.Path("/_ping").Methods("GET").HandlerFunc(s.handlerWrapper(s.pingDocker))
 	s.mux.Path("/images/load").Methods("POST").HandlerFunc(s.handlerWrapper(s.loadImage))
@@ -174,8 +180,8 @@ func (s *DockerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Returns default http.Handler mux, it allows customHandlers to call the
-// default behavior if wanted.
+// DefaultHandler returns default http.Handler mux, it allows customHandlers to
+// call the default behavior if wanted.
 func (s *DockerServer) DefaultHandler() http.Handler {
 	return s.mux
 }
@@ -279,7 +285,7 @@ func (s *DockerServer) createContainer(w http.ResponseWriter, r *http.Request) {
 	ports := map[docker.Port][]docker.PortBinding{}
 	for port := range config.ExposedPorts {
 		ports[port] = []docker.PortBinding{{
-			HostIp:   "0.0.0.0",
+			HostIP:   "0.0.0.0",
 			HostPort: strconv.Itoa(mathrand.Int() % 65536),
 		}}
 	}
@@ -518,9 +524,13 @@ func (s *DockerServer) commitContainer(w http.ResponseWriter, r *http.Request) {
 		Config:    config,
 	}
 	repository := r.URL.Query().Get("repo")
+	tag := r.URL.Query().Get("tag")
 	s.iMut.Lock()
 	s.images = append(s.images, image)
 	if repository != "" {
+		if tag != "" {
+			repository += ":" + tag
+		}
 		s.imgIDs[repository] = image.ID
 	}
 	s.iMut.Unlock()
@@ -576,20 +586,24 @@ func (s *DockerServer) buildImage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *DockerServer) pullImage(w http.ResponseWriter, r *http.Request) {
-	repository := r.URL.Query().Get("fromImage")
+	fromImageName := r.URL.Query().Get("fromImage")
 	image := docker.Image{
 		ID: s.generateID(),
 	}
 	s.iMut.Lock()
 	s.images = append(s.images, image)
-	if repository != "" {
-		s.imgIDs[repository] = image.ID
+	if fromImageName != "" {
+		s.imgIDs[fromImageName] = image.ID
 	}
 	s.iMut.Unlock()
 }
 
 func (s *DockerServer) pushImage(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
+	tag := r.URL.Query().Get("tag")
+	if tag != "" {
+		name += ":" + tag
+	}
 	s.iMut.RLock()
 	if _, ok := s.imgIDs[name]; !ok {
 		s.iMut.RUnlock()
@@ -601,12 +615,38 @@ func (s *DockerServer) pushImage(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Pushed")
 }
 
+func (s *DockerServer) tagImage(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	s.iMut.RLock()
+	if _, ok := s.imgIDs[name]; !ok {
+		s.iMut.RUnlock()
+		http.Error(w, "No such image", http.StatusNotFound)
+		return
+	}
+	s.iMut.RUnlock()
+	s.iMut.Lock()
+	defer s.iMut.Unlock()
+	newRepo := r.URL.Query().Get("repo")
+	newTag := r.URL.Query().Get("tag")
+	if newTag != "" {
+		newRepo += ":" + newTag
+	}
+	s.imgIDs[newRepo] = s.imgIDs[name]
+	w.WriteHeader(http.StatusCreated)
+}
+
 func (s *DockerServer) removeImage(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	s.iMut.RLock()
 	var tag string
 	if img, ok := s.imgIDs[id]; ok {
 		id, tag = img, id
+	}
+	var tags []string
+	for tag, taggedID := range s.imgIDs {
+		if taggedID == id {
+			tags = append(tags, tag)
+		}
 	}
 	s.iMut.RUnlock()
 	_, index, err := s.findImageByID(id)
@@ -617,8 +657,10 @@ func (s *DockerServer) removeImage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 	s.iMut.Lock()
 	defer s.iMut.Unlock()
-	s.images[index] = s.images[len(s.images)-1]
-	s.images = s.images[:len(s.images)-1]
+	if len(tags) < 2 {
+		s.images[index] = s.images[len(s.images)-1]
+		s.images = s.images[:len(s.images)-1]
+	}
 	if tag != "" {
 		delete(s.imgIDs, tag)
 	}
@@ -693,4 +735,69 @@ func (s *DockerServer) getImage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/tar")
 
+}
+
+func (s *DockerServer) createExecContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	container, _, err := s.findContainer(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	exec := docker.ExecInspect{
+		ID:        "id-exec-created-by-test",
+		Container: *container,
+	}
+	var params docker.CreateExecOptions
+	err = json.NewDecoder(r.Body).Decode(&params)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(params.Cmd) > 0 {
+		exec.ProcessConfig.EntryPoint = params.Cmd[0]
+		if len(params.Cmd) > 1 {
+			exec.ProcessConfig.Arguments = params.Cmd[1:]
+		}
+	}
+	s.execs = append(s.execs, &exec)
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"Id": exec.ID})
+
+}
+
+func (s *DockerServer) startExecContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	for _, exec := range s.execs {
+		if exec.ID == id {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (s *DockerServer) resizeExecContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	for _, exec := range s.execs {
+		if exec.ID == id {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (s *DockerServer) inspectExecContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	for _, exec := range s.execs {
+		if exec.ID == id {
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(exec)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server_test.go
@@ -277,6 +277,27 @@ func TestCommitContainerComplete(t *testing.T) {
 	}
 }
 
+func TestCommitContainerWithTag(t *testing.T) {
+	server := DockerServer{}
+	server.imgIDs = make(map[string]string)
+	addContainers(&server, 2)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	queryString := "container=" + server.containers[0].ID + "&repo=tsuru/python&tag=v1"
+	request, _ := http.NewRequest("POST", "/commit?"+queryString, nil)
+	server.ServeHTTP(recorder, request)
+	image := server.images[0]
+	if image.Parent != server.containers[0].Image {
+		t.Errorf("CommitContainer: wrong parent image. Want %q. Got %q.", server.containers[0].Image, image.Parent)
+	}
+	if image.Container != server.containers[0].ID {
+		t.Errorf("CommitContainer: wrong container. Want %q. Got %q.", server.containers[0].ID, image.Container)
+	}
+	if id := server.imgIDs["tsuru/python:v1"]; id != image.ID {
+		t.Errorf("CommitContainer: wrong ID saved for repository. Want %q. Got %q.", image.ID, id)
+	}
+}
+
 func TestCommitContainerInvalidRun(t *testing.T) {
 	server := DockerServer{}
 	addContainers(&server, 1)
@@ -778,6 +799,17 @@ func TestPushImage(t *testing.T) {
 	}
 }
 
+func TestPushImageWithTag(t *testing.T) {
+	server := DockerServer{imgIDs: map[string]string{"tsuru/python:v1": "a123"}}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/tsuru/python/push?tag=v1", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("PushImage: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+}
+
 func TestPushImageNotFound(t *testing.T) {
 	server := DockerServer{}
 	server.buildMuxer()
@@ -786,6 +818,45 @@ func TestPushImageNotFound(t *testing.T) {
 	server.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusNotFound {
 		t.Errorf("PushImage: wrong status. Want %d. Got %d.", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestTagImage(t *testing.T) {
+	server := DockerServer{imgIDs: map[string]string{"tsuru/python": "a123"}}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/tsuru/python/tag?repo=tsuru/new-python", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusCreated {
+		t.Errorf("TagImage: wrong status. Want %d. Got %d.", http.StatusCreated, recorder.Code)
+	}
+	if server.imgIDs["tsuru/python"] != server.imgIDs["tsuru/new-python"] {
+		t.Errorf("TagImage: did not tag the image")
+	}
+}
+
+func TestTagImageWithRepoAndTag(t *testing.T) {
+	server := DockerServer{imgIDs: map[string]string{"tsuru/python": "a123"}}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/tsuru/python/tag?repo=tsuru/new-python&tag=v1", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusCreated {
+		t.Errorf("TagImage: wrong status. Want %d. Got %d.", http.StatusCreated, recorder.Code)
+	}
+	if server.imgIDs["tsuru/python"] != server.imgIDs["tsuru/new-python:v1"] {
+		t.Errorf("TagImage: did not tag the image")
+	}
+}
+
+func TestTagImageNotFound(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/tsuru/python/tag", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("TagImage: wrong status. Want %d. Got %d.", http.StatusNotFound, recorder.Code)
 	}
 }
 
@@ -915,6 +986,36 @@ func TestRemoveImageByName(t *testing.T) {
 	}
 }
 
+func TestRemoveImageWithMultipleTags(t *testing.T) {
+	server := DockerServer{}
+	addImages(&server, 1, true)
+	server.buildMuxer()
+	imgID := server.images[0].ID
+	imgName := "docker/python-" + imgID
+	server.imgIDs["docker/python-wat"] = imgID
+	recorder := httptest.NewRecorder()
+	path := fmt.Sprintf("/images/%s", imgName)
+	request, _ := http.NewRequest("DELETE", path, nil)
+	server.ServeHTTP(recorder, request)
+	_, ok := server.imgIDs[imgName]
+	if ok {
+		t.Error("RemoveImage: did not remove image tag name.")
+	}
+	id, ok := server.imgIDs["docker/python-wat"]
+	if !ok {
+		t.Error("RemoveImage: removed the wrong tag name.")
+	}
+	if id != imgID {
+		t.Error("RemoveImage: disassociated the wrong ID from the tag")
+	}
+	if len(server.images) < 1 {
+		t.Fatal("RemoveImage: removed the image, but should keep it")
+	}
+	if server.images[0].ID != imgID {
+		t.Error("RemoveImage: changed the ID of the image!")
+	}
+}
+
 func TestPrepareFailure(t *testing.T) {
 	server := DockerServer{failures: make(map[string]string)}
 	server.buildMuxer()
@@ -1032,5 +1133,85 @@ func TestDefaultHandler(t *testing.T) {
 	defer server.listener.Close()
 	if server.mux != server.DefaultHandler() {
 		t.Fatalf("DefaultHandler: Expected to return server.mux, got: %#v", server.DefaultHandler())
+	}
+}
+
+func TestCreateExecContainer(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 2)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Cmd": ["bash", "-c", "ls"]}`
+	path := fmt.Sprintf("/containers/%s/exec", server.containers[0].ID)
+	request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("CreateExec: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	serverExec := server.execs[0]
+	var got docker.Exec
+	err := json.NewDecoder(recorder.Body).Decode(&got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != serverExec.ID {
+		t.Errorf("CreateExec: wrong value. Want %#v. Got %#v.", serverExec.ID, got.ID)
+	}
+	expected := docker.ExecInspect{
+		ID: got.ID,
+		ProcessConfig: docker.ExecProcessConfig{
+			EntryPoint: "bash",
+			Arguments:  []string{"-c", "ls"},
+		},
+		Container: *server.containers[0],
+	}
+	if !reflect.DeepEqual(*serverExec, expected) {
+		t.Errorf("InspectContainer: wrong value. Want:\n%#v\nGot:\n%#v\n", expected, *serverExec)
+	}
+}
+
+func TestInspectExecContainer(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 1)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Cmd": ["bash", "-c", "ls"]}`
+	path := fmt.Sprintf("/containers/%s/exec", server.containers[0].ID)
+	request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("CreateExec: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	var got docker.Exec
+	err := json.NewDecoder(recorder.Body).Decode(&got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path = fmt.Sprintf("/exec/%s/json", got.ID)
+	request, _ = http.NewRequest("GET", path, nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("CreateExec: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	var got2 docker.ExecInspect
+	err = json.NewDecoder(recorder.Body).Decode(&got2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := docker.ExecInspect{
+		ID: got.ID,
+		ProcessConfig: docker.ExecProcessConfig{
+			EntryPoint: "bash",
+			Arguments:  []string{"-c", "ls"},
+		},
+		Container: *server.containers[0],
+	}
+	got2.Container.State.StartedAt = expected.Container.State.StartedAt
+	got2.Container.State.FinishedAt = expected.Container.State.FinishedAt
+	got2.Container.Config = expected.Container.Config
+	got2.Container.Created = expected.Container.Created
+	got2.Container.NetworkSettings = expected.Container.NetworkSettings
+	if !reflect.DeepEqual(got2, expected) {
+		t.Errorf("InspectContainer: wrong value. Want:\n%#v\nGot:\n%#v\n", expected, got2)
 	}
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/writer.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/writer.go
@@ -13,9 +13,9 @@ import (
 type stdType [8]byte
 
 var (
-	stdin  stdType = stdType{0: 0}
-	stdout stdType = stdType{0: 1}
-	stderr stdType = stdType{0: 2}
+	stdin  = stdType{0: 0}
+	stdout = stdType{0: 1}
+	stderr = stdType{0: 2}
 )
 
 type stdWriter struct {

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tls.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tls.go
@@ -1,0 +1,100 @@
+// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// The content is borrowed from Docker's own source code to provide a simple
+// tls based dialer
+
+package docker
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"strings"
+	"time"
+)
+
+type tlsClientCon struct {
+	*tls.Conn
+	rawConn net.Conn
+}
+
+func (c *tlsClientCon) CloseWrite() error {
+	// Go standard tls.Conn doesn't provide the CloseWrite() method so we do it
+	// on its underlying connection.
+	if cwc, ok := c.rawConn.(interface {
+		CloseWrite() error
+	}); ok {
+		return cwc.CloseWrite()
+	}
+	return nil
+}
+
+func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Config) (net.Conn, error) {
+	// We want the Timeout and Deadline values from dialer to cover the
+	// whole process: TCP connection and TLS handshake. This means that we
+	// also need to start our own timers now.
+	timeout := dialer.Timeout
+
+	if !dialer.Deadline.IsZero() {
+		deadlineTimeout := dialer.Deadline.Sub(time.Now())
+		if timeout == 0 || deadlineTimeout < timeout {
+			timeout = deadlineTimeout
+		}
+	}
+
+	var errChannel chan error
+
+	if timeout != 0 {
+		errChannel = make(chan error, 2)
+		time.AfterFunc(timeout, func() {
+			errChannel <- errors.New("")
+		})
+	}
+
+	rawConn, err := dialer.Dial(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	colonPos := strings.LastIndex(addr, ":")
+	if colonPos == -1 {
+		colonPos = len(addr)
+	}
+	hostname := addr[:colonPos]
+
+	// If no ServerName is set, infer the ServerName
+	// from the hostname we're connecting to.
+	if config.ServerName == "" {
+		// Make a copy to avoid polluting argument or default.
+		c := *config
+		c.ServerName = hostname
+		config = &c
+	}
+
+	conn := tls.Client(rawConn, config)
+
+	if timeout == 0 {
+		err = conn.Handshake()
+	} else {
+		go func() {
+			errChannel <- conn.Handshake()
+		}()
+
+		err = <-errChannel
+	}
+
+	if err != nil {
+		rawConn.Close()
+		return nil, err
+	}
+
+	// This is Docker difference with standard's crypto/tls package: returned a
+	// wrapper which holds both the TLS and raw connections.
+	return &tlsClientCon{conn, rawConn}, nil
+}
+
+func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {
+	return tlsDialWithDialer(new(net.Dialer), network, addr, config)
+}

--- a/events/client.go
+++ b/events/client.go
@@ -1,0 +1,41 @@
+package events
+
+import (
+	//"fmt"
+	"github.com/fsouza/go-dockerclient"
+	"os"
+	"path"
+)
+
+const (
+	defaultUnixSocket = "unix:///var/run/docker.sock"
+	defaultApiVersion = "1.16"
+)
+
+func DockerClient(useDockerConnectEnvVars bool) (*docker.Client, error) {
+	apiVersion := getenv("DOCKER_API_VERSION", defaultApiVersion)
+	endpoint := defaultUnixSocket
+
+	if useDockerConnectEnvVars {
+		endpoint = os.Getenv("DOCKER_HOST")
+		certPath := os.Getenv("DOCKER_CERT_PATH")
+		tlsVerify := os.Getenv("DOCKER_TLS_VERIFY") != ""
+
+		if tlsVerify && certPath != "" {
+			cert := path.Join(certPath, "cert.pem")
+			key := path.Join(certPath, "key.pem")
+			ca := path.Join(certPath, "ca.pem")
+			return docker.NewVersionedTLSClient(endpoint, cert, key, ca, apiVersion)
+		}
+	}
+
+	return docker.NewVersionedClient(endpoint, apiVersion)
+}
+
+func getenv(key string, defaultVal string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		val = defaultVal
+	}
+	return val
+}

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"os"
+	"testing"
+)
+
+func TestEventListener(t *testing.T) {
+
+}
+
+func newDockerClient() (*docker.Client, error) {
+	useDockerConnectEnvVars := os.Getenv("CATTLE_DOCKER_USE_BOOT2DOCKER") == "true"
+	return DockerClient(useDockerConnectEnvVars)
+}
+
+func TestDockerClient(t *testing.T) {
+	client, err := newDockerClient()
+	if err != nil {
+		t.Fatalf("Couldn't connect to docker.", err)
+	}
+	_, err = client.ListImages(docker.ListImagesOptions{All: false})
+	if err != nil {
+		t.Fatalf("Client not working.", err)
+	}
+}

--- a/scripts/build
+++ b/scripts/build
@@ -6,9 +6,9 @@ if [ -f ./build/bootstrap.envs ];then
     . ./build/bootstrap.envs
 fi
 
-export GOPATH=$(pwd)/Godeps/_workspace:$(pwd)/gopath
+. ./scripts/common_functions
 
-PACKAGE=./gopath/src/$(<.package)
+set_project_vars
 
 if [ -L ${PACKAGE} ]; then
     rm ${PACKAGE}
@@ -22,4 +22,4 @@ fi
 echo export GOPATH=$GOPATH
 
 mkdir -p bin
-go build -o bin/host-api
+go build -o bin/${PROJECT}

--- a/scripts/common_functions
+++ b/scripts/common_functions
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+function set_project_vars() {
+    PACKAGE=./gopath/src/$(<.package)
+    PROJECT=$(basename $PACKAGE)
+
+    export GOPATH=$(pwd)/Godeps/_workspace:$(pwd)/gopath
+}

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,19 @@
 
 set -e
 
+cd $(dirname $0)/..
+
+if [ -x "$(which wrapdocker)" ]; then
+    wrapdocker > /tmp/docker.log 2>&1
+    docker ps -q
+fi
+
+. ./scripts/common_functions
+
+set_project_vars
+
+go test ./...
+
 result=$(find . -name "*.go" | grep -v ./Godeps | xargs gofmt -s -l)
 for i in $result; do
     echo $i


### PR DESCRIPTION
This PR lays the ground work for docker event listening functionality that we're going to add. I'd like to merge this prep PR separately because it has a lot of noise in it from updating Godeps and modifying build scripts.

This PR does the following:
* Introduces a working docker client with tests to prove we can connect to docker
  * Pulls fsouza/go-dockerclient and its transient dependencies into godeps
  * Updates docker dependencies and pins them to 1.5.0
* Updates the base image used by drone and our `wrap` script from `golang` to `rancher/dind:v0.2.0`.*
* Executes `go test` as part of the CI workflow


\*`rancher/dind:v0.2.0` was updated to support golang builds in this PR: https://github.com/rancherio/docker-dind-base/pull/7