### PR TITLE
Allows touch the python agent stamp regardless of success/failure

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -2,6 +2,8 @@
 
 source ${CATTLE_HOME:-/var/lib/cattle}/common/scripts.sh
 
+trap "touch $CATTLE_HOME/.pyagent-stamp" exit
+
 cd $(dirname $0)
 
 mkdir -p ${CATTLE_HOME}/bin
@@ -10,4 +12,3 @@ cp bin/host-api ${CATTLE_HOME}/bin
 
 chmod +x ${CATTLE_HOME}/bin/host-api
 
-touch $CATTLE_HOME/.pyagent-stamp


### PR DESCRIPTION
When the host-api tries to update as a config item the host-api
file may be locked and that makes it so that we can't stage a new
file.  By always touching the stamp we force python agent to restart
which will kill host-api and download a new one.