### PR TITLE
Fix state watcher tests

### DIFF
--- a/events/entry.go
+++ b/events/entry.go
@@ -44,7 +44,7 @@ func (de *DockerEventsProcessor) Process() error {
 	}
 	router.Start()
 
-	rancherStateWatcher := newRancherStateWatcher(router.listener, getContainerStateDir())
+	rancherStateWatcher := newRancherStateWatcher(router.listener, getContainerStateDir(), nil)
 	go rancherStateWatcher.watch()
 
 	listOpts := docker.ListContainersOptions{


### PR DESCRIPTION
The tests for watching the rancher container state directory were not
cleaning up after themselves properly and leaving watchers and health
checkers running. This caused random failures because the tests
wouldn't be able to delete and recreate the state directory properly.