### PR TITLE
Native docker lifecycle events

### DIFF
--- a/events/entry_test.go
+++ b/events/entry_test.go
@@ -30,8 +30,8 @@ func TestProcessDockerEvents(t *testing.T) {
 		handlerFunc: hFn,
 	}
 	processor.getHandlers = func(dockerClient *docker.Client,
-		rancherClient *rclient.RancherClient) (map[string]Handler, error) {
-		return map[string]Handler{"start": handler}, nil
+		rancherClient *rclient.RancherClient) (map[string][]Handler, error) {
+		return map[string][]Handler{"start": []Handler{handler}}, nil
 	}
 
 	// Create pre-existing containers before starting event listener
@@ -85,17 +85,17 @@ func TestGetHandlers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Cattle API config params not set, so CreateHandler shouldn't get configured
-	if len(handlers) != 1 {
+	// Cattle API config params not set, so SendToRancherHandler shouldn't get configured
+	if len(handlers) != 1 && len(handlers["start"]) != 1 {
 		t.Fatalf("Expected 1 configured hanlder: %v", handlers)
 	}
 
-	// RancherClient is not nil, so CreateHandler should be configured
+	// RancherClient is not nil, so SendToRancherHandler should be configured
 	handlers, err = getHandlersFn(dockerClient, &rclient.RancherClient{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(handlers) != 2 {
-		t.Fatalf("Expected 2 configured hanlders: %v, %#v", len(handlers), handlers)
+	if len(handlers) != 6 {
+		t.Fatalf("Expected 6 configured hanlders: %v, %#v", len(handlers), handlers)
 	}
 }

--- a/events/event_router_test.go
+++ b/events/event_router_test.go
@@ -27,7 +27,7 @@ func TestEventRouter(t *testing.T) {
 	handler := &testHandler{
 		handlerFunc: hFn,
 	}
-	handlers := map[string]Handler{"create": handler}
+	handlers := map[string][]Handler{"create": []Handler{handler}}
 	dockerClient, _ := NewDockerClient(useEnvVars())
 	router, _ := NewEventRouter(5, 5, dockerClient, handlers)
 	defer router.Stop()
@@ -65,7 +65,7 @@ func TestWorkerTimeout(t *testing.T) {
 		handlerFunc: hFn,
 	}
 
-	handlers := map[string]Handler{"create": handler}
+	handlers := map[string][]Handler{"create": []Handler{handler}}
 
 	dockerClient, _ := NewDockerClient(useEnvVars())
 	router, _ := NewEventRouter(1, 1, dockerClient, handlers)

--- a/events/rancher_state_watcher.go
+++ b/events/rancher_state_watcher.go
@@ -13,6 +13,7 @@ import (
 )
 
 const healthCheckFileName = ".healthcheck"
+const simulatedEvent = "-simulated-"
 
 type newWatcherFnDef func() (*fsnotify.Watcher, error)
 
@@ -112,7 +113,7 @@ func watchInternalFn(eventChannel chan<- *docker.APIEvents, watchDir string, hea
 					dockerEvent := &docker.APIEvents{
 						ID:     id,
 						Status: "start",
-						From:   "watcher-simulated",
+						From:   simulatedEvent,
 					}
 					eventChannel <- dockerEvent
 				}

--- a/events/rancher_state_watcher_test.go
+++ b/events/rancher_state_watcher_test.go
@@ -137,7 +137,7 @@ func assertEvent(fileName string, eventChan chan *docker.APIEvents, t *testing.T
 	select {
 	case event := <-eventChan:
 		if event.ID != fileName || event.Status != "start" ||
-			event.From != "watcher-simulated" || event.Time != 0 {
+			event.From != simulatedEvent || event.Time != 0 {
 			t.Fatalf("Unexpected event: %#v", event)
 		}
 	case <-time.NewTimer(time.Millisecond * 300).C:

--- a/events/send_to_rancher_handler_test.go
+++ b/events/send_to_rancher_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCreateHandler(t *testing.T) {
+func TestSendToRancherHandler(t *testing.T) {
 	dockerClient := prep(t)
 
 	injectedIp := "10.1.2.3"
@@ -27,7 +27,7 @@ func TestCreateHandler(t *testing.T) {
 	}
 	rancher := mockRancherClient(expectedEvent, t)
 
-	handler := &CreateHandler{client: dockerClient, rancher: rancher, hostUuid: hostUuid}
+	handler := &SendToRancherHandler{client: dockerClient, rancher: rancher, hostUuid: hostUuid}
 
 	if err := handler.Handle(event); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Sends start/stop/kill/destroy events to Rancher.
Don't merge yet. Requires coordination with forthcoming cattle PR.