### PR TITLE
Use labels for rancher ip

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,3 @@
-image: rancher/dind:v0.2.0
+image: rancher/dind:v0.3.0
 script:
  - ./scripts/ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/dind:v0.2.0
+FROM rancher/dind:v0.3.0
 COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -54,7 +54,7 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Rev": "59b423db81e5894ca7460652f1b206fc72d85750"
+			"Rev": "0ba7f0a32981ca4c1043c245017eb099708695ef"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.2.2
   - 1.3.1
   - 1.4
   - tip
@@ -8,7 +7,6 @@ env:
   - GOARCH=amd64
   - GOARCH=386
 install:
-  - go get -d ./...
+  - make testdeps
 script:
-  - go test ./...
-  - ./testing/bin/fmtpolice
+  - make test

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/AUTHORS
@@ -1,10 +1,12 @@
 # This is the official list of go-dockerclient authors for copyright purposes.
 
+Adam Bell-Hanssen <adamb@aller.no>
 Aldrin Leal <aldrin@leal.eng.br>
 Andreas Jaekle <andreas@jaekle.net>
 Andrews Medina <andrewsmedina@gmail.com>
 Artem Sidorenko <artem@2realities.com>
 Andy Goldstein <andy.goldstein@redhat.com>
+Ben Marini <ben@remind101.com>
 Ben McCann <benmccann.com>
 Brian Lalor <blalor@bravo5.org>
 Burke Libbey <burke@libbey.me>
@@ -14,14 +16,17 @@ Cheah Chu Yeow <chuyeow@gmail.com>
 cheneydeng <cheneydeng@qq.com>
 CMGS <ilskdw@gmail.com>
 Daniel, Dao Quang Minh <dqminh89@gmail.com>
+Darren Shepherd <darren@rancher.com>
 David Huie <dahuie@gmail.com>
 Dawn Chen <dawnchen@google.com>
 Ed <edrocksit@gmail.com>
 Eric Anderson <anderson@copperegg.com>
 Fabio Rehm <fgrehm@gmail.com>
- Fatih Arslan <ftharsln@gmail.com>
+Fatih Arslan <ftharsln@gmail.com>
 Flavia Missi <flaviamissi@gmail.com>
 Francisco Souza <f@souza.cc>
+Guillermo Álvarez Fernández <guillermo@cientifico.net>
+James Bardin <jbardin@litl.com>
 Jari Kolehmainen <jari.kolehmainen@digia.com>
 Jason Wilder <jwilder@litl.com>
 Jawher Moussa <jawher.moussa@gmail.com>
@@ -32,7 +37,10 @@ Johan Euphrosine <proppy@google.com>
 Kamil Domanski <kamil@domanski.co>
 Karan Misra <kidoman@gmail.com>
 Kim, Hirokuni <hirokuni.kim@kvh.co.jp>
+Kyle Allan <kallan357@gmail.com>
+liron-l <levinlir@gmail.com>
 Lucas Clemente <lucas@clemente.io>
+Lucas Weiblen <lucasweiblen@gmail.com>
 Mantas Matelis <mmatelis@coursera.org>
 Martin Sweeney <martin@sweeney.io>
 Máximo Cuadros Ortiz <mcuadros@gmail.com>
@@ -42,12 +50,15 @@ Mrunal Patel <mrunalp@gmail.com>
 Nick Ethier <ncethier@gmail.com>
 Omeid Matten <public@omeid.me>
 Paul Morie <pmorie@gmail.com>
+Paul Weil <pweil@redhat.com>
+Peter Edge <peter.edge@gmail.com>
 Peter Jihoon Kim <raingrove@gmail.com>
 Philippe Lafoucrière <philippe.lafoucriere@tech-angels.com>
 Rafe Colton <rafael.colton@gmail.com>
 Rob Miller <rob@kalistra.com>
 Robert Williamson <williamson.robert@gmail.com>
 Salvador Gironès <salvadorgirones@gmail.com>
+Sam Rijs <srijs@airpost.net>
 Simon Eskildsen <sirup@sirupsen.com>
 Simon Menke <simon.menke@gmail.com>
 Skolos <skolos@gopherlab.com>
@@ -56,6 +67,8 @@ Sridhar Ratnakumar <sridharr@activestate.com>
 Summer Mousa <smousa@zenoss.com>
 Tarsis Azevedo <tarsis@corp.globo.com>
 Tim Schindler <tim@catalyst-zero.com>
+Tobi Knaup <tobi@mesosphere.io>
+Vincenzo Prignano <vincenzo.prignano@gmail.com>
 Wiliam Souza <wiliamsouza83@gmail.com>
 Ye Yin <eyniy@qq.com>
 Yuriy Bogdanov <chinsay@gmail.com>

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/LICENSE
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, go-dockerclient authors
+Copyright (c) 2015, go-dockerclient authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/Makefile
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/Makefile
@@ -1,0 +1,35 @@
+.PHONY: \
+	all \
+	deps \
+	updatedeps \
+	testdeps \
+	updatetestdeps \
+	cov \
+	test \
+	clean
+
+all: test
+
+deps:
+	go get -d -v ./...
+
+updatedeps:
+	go get -d -v -u -f ./...
+
+testdeps:
+	go get -d -v -t ./...
+
+updatetestdeps:
+	go get -d -v -t -u -f ./...
+
+cov: testdeps
+	go get -v github.com/axw/gocov/gocov
+	go get golang.org/x/tools/cmd/cover
+	gocov test | gocov report
+
+test: testdeps
+	go test ./...
+	./testing/bin/fmtpolice
+
+clean:
+	go clean ./...

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/README.markdown
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/README.markdown
@@ -3,11 +3,12 @@
 [![Build Status](https://drone.io/github.com/fsouza/go-dockerclient/status.png)](https://drone.io/github.com/fsouza/go-dockerclient/latest)
 [![Build Status](https://travis-ci.org/fsouza/go-dockerclient.png)](https://travis-ci.org/fsouza/go-dockerclient)
 
-[![GoDoc](http://godoc.org/github.com/fsouza/go-dockerclient?status.png)](http://godoc.org/github.com/fsouza/go-dockerclient)
+[![GoDoc](https://godoc.org/github.com/fsouza/go-dockerclient?status.png)](https://godoc.org/github.com/fsouza/go-dockerclient)
 
-This package presents a client for the Docker remote API.
+This package presents a client for the Docker remote API. It also provides
+support for the extensions in the [Swarm API](https://docs.docker.com/swarm/API/).
 
-For more details, check the [remote API documentation](http://docs.docker.io/en/latest/reference/api/docker_remote_api/).
+For more details, check the [remote API documentation](http://docs.docker.com/en/latest/reference/api/docker_remote_api/).
 
 ## Example
 
@@ -15,22 +16,49 @@ For more details, check the [remote API documentation](http://docs.docker.io/en/
 package main
 
 import (
-        "fmt"
-        "github.com/fsouza/go-dockerclient"
+	"fmt"
+
+	"github.com/fsouza/go-dockerclient"
 )
 
 func main() {
-        endpoint := "unix:///var/run/docker.sock"
-        client, _ := docker.NewClient(endpoint)
-        imgs, _ := client.ListImages(docker.ListImagesOptions{All: false})
-        for _, img := range imgs {
-                fmt.Println("ID: ", img.ID)
-                fmt.Println("RepoTags: ", img.RepoTags)
-                fmt.Println("Created: ", img.Created)
-                fmt.Println("Size: ", img.Size)
-                fmt.Println("VirtualSize: ", img.VirtualSize)
-                fmt.Println("ParentId: ", img.ParentID)
-        }
+	endpoint := "unix:///var/run/docker.sock"
+	client, _ := docker.NewClient(endpoint)
+	imgs, _ := client.ListImages(docker.ListImagesOptions{All: false})
+	for _, img := range imgs {
+		fmt.Println("ID: ", img.ID)
+		fmt.Println("RepoTags: ", img.RepoTags)
+		fmt.Println("Created: ", img.Created)
+		fmt.Println("Size: ", img.Size)
+		fmt.Println("VirtualSize: ", img.VirtualSize)
+		fmt.Println("ParentId: ", img.ParentID)
+	}
+}
+```
+
+## Using with Boot2Docker
+
+Boot2Docker runs Docker with TLS enabled. In order to instantiate the client you should use NewTLSClient, passing the endpoint and path for key and certificates as parameters.
+
+For more details about TLS support in Boot2Docker, please refer to [TLS support](https://github.com/boot2docker/boot2docker#tls-support) on Boot2Docker's readme.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+func main() {
+	endpoint := "tcp://[ip]:[port]"
+	path := os.Getenv("DOCKER_CERT_PATH")
+	ca := fmt.Sprintf("%s/ca.pem", path)
+	cert := fmt.Sprintf("%s/cert.pem", path)
+	key := fmt.Sprintf("%s/key.pem", path)
+	client, _ := docker.NewTLSClient(endpoint, cert, key, ca)
+	// use client
 }
 ```
 
@@ -38,5 +66,4 @@ func main() {
 
 You can run the tests with:
 
-    go get -d ./...
-    go test ./...
+    make test

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/auth.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/auth.go
@@ -1,0 +1,83 @@
+// Copyright 2015 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"strings"
+)
+
+// AuthConfiguration represents authentication options to use in the PushImage
+// method. It represents the authentication in the Docker index server.
+type AuthConfiguration struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Email         string `json:"email,omitempty"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+}
+
+// AuthConfigurations represents authentication options to use for the
+// PushImage method accommodating the new X-Registry-Config header
+type AuthConfigurations struct {
+	Configs map[string]AuthConfiguration `json:"configs"`
+}
+
+// dockerConfig represents a registry authentation configuration from the
+// .dockercfg file.
+type dockerConfig struct {
+	Auth  string `json:"auth"`
+	Email string `json:"email"`
+}
+
+// NewAuthConfigurationsFromDockerCfg returns AuthConfigurations from the
+// ~/.dockercfg file.
+func NewAuthConfigurationsFromDockerCfg() (*AuthConfigurations, error) {
+	p := path.Join(os.Getenv("HOME"), ".dockercfg")
+	r, err := os.Open(p)
+	if err != nil {
+		return nil, err
+	}
+	return NewAuthConfigurations(r)
+}
+
+// NewAuthConfigurations returns AuthConfigurations from a JSON encoded string in the
+// same format as the .dockercfg file.
+func NewAuthConfigurations(r io.Reader) (*AuthConfigurations, error) {
+	var auth *AuthConfigurations
+	var confs map[string]dockerConfig
+	if err := json.NewDecoder(r).Decode(&confs); err != nil {
+		return nil, err
+	}
+	auth, err := authConfigs(confs)
+	if err != nil {
+		return nil, err
+	}
+	return auth, nil
+}
+
+// authConfigs converts a dockerConfigs map to a AuthConfigurations object.
+func authConfigs(confs map[string]dockerConfig) (*AuthConfigurations, error) {
+	c := &AuthConfigurations{
+		Configs: make(map[string]AuthConfiguration),
+	}
+	for reg, conf := range confs {
+		data, err := base64.StdEncoding.DecodeString(conf.Auth)
+		if err != nil {
+			return nil, err
+		}
+		userpass := strings.Split(string(data), ":")
+		c.Configs[reg] = AuthConfiguration{
+			Email:         conf.Email,
+			Username:      userpass[0],
+			Password:      userpass[1],
+			ServerAddress: reg,
+		}
+	}
+	return c, nil
+}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/auth_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/auth_test.go
@@ -1,0 +1,37 @@
+// Copyright 2015 go-dockerclient authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package docker
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAuthConfig(t *testing.T) {
+	auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	read := strings.NewReader(fmt.Sprintf(`{"docker.io":{"auth":"%s","email":"user@example.com"}}`, auth))
+	ac, err := NewAuthConfigurations(read)
+	if err != nil {
+		t.Error(err)
+	}
+	c, ok := ac.Configs["docker.io"]
+	if !ok {
+		t.Error("NewAuthConfigurations: Expected Configs to contain docker.io")
+	}
+	if got, want := c.Email, "user@example.com"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Email: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.Username, "user"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Username: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.Password, "pass"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].Password: wrong result. Want %q. Got %q`, want, got)
+	}
+	if got, want := c.ServerAddress, "docker.io"; got != want {
+		t.Errorf(`AuthConfigurations.Configs["docker.io"].ServerAddress: wrong result. Want %q. Got %q`, want, got)
+	}
+}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -34,7 +34,7 @@ var (
 	// ErrConnectionRefused is returned when the client cannot connect to the given endpoint.
 	ErrConnectionRefused = errors.New("cannot connect to Docker endpoint")
 
-	apiVersion1_12, _ = NewAPIVersion("1.12")
+	apiVersion112, _ = NewAPIVersion("1.12")
 )
 
 // APIVersion is an internal representation of a version of the Remote API.
@@ -143,7 +143,7 @@ func NewClient(endpoint string) (*Client, error) {
 // server endpoint, key and certificates . It will use the latest remote API version
 // available in the server.
 func NewTLSClient(endpoint string, cert, key, ca string) (*Client, error) {
-	client, err := NewVersionnedTLSClient(endpoint, cert, key, ca, "")
+	client, err := NewVersionedTLSClient(endpoint, cert, key, ca, "")
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func NewTLSClient(endpoint string, cert, key, ca string) (*Client, error) {
 // NewVersionedClient returns a Client instance ready for communication with
 // the given server endpoint, using a specific remote API version.
 func NewVersionedClient(endpoint string, apiVersionString string) (*Client, error) {
-	u, err := parseEndpoint(endpoint)
+	u, err := parseEndpoint(endpoint, false)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func NewVersionnedTLSClient(endpoint string, cert, key, ca, apiVersionString str
 // NewVersionedTLSClient returns a Client instance ready for TLS communications with the givens
 // server endpoint, key and certificates, using a specific remote API version.
 func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
-	u, err := parseEndpoint(endpoint)
+	u, err := parseEndpoint(endpoint, true)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (c *Client) checkAPIVersion() error {
 // See http://goo.gl/stJENm for more details.
 func (c *Client) Ping() error {
 	path := "/_ping"
-	body, status, err := c.do("GET", path, nil)
+	body, status, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func (c *Client) Ping() error {
 }
 
 func (c *Client) getServerAPIVersionString() (version string, err error) {
-	body, status, err := c.do("GET", "/version", nil)
+	body, status, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -279,10 +279,15 @@ func (c *Client) getServerAPIVersionString() (version string, err error) {
 	return version, nil
 }
 
-func (c *Client) do(method, path string, data interface{}) ([]byte, int, error) {
+type doOptions struct {
+	data      interface{}
+	forceJSON bool
+}
+
+func (c *Client) do(method, path string, doOptions doOptions) ([]byte, int, error) {
 	var params io.Reader
-	if data != nil {
-		buf, err := json.Marshal(data)
+	if doOptions.data != nil || doOptions.forceJSON {
+		buf, err := json.Marshal(doOptions.data)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -299,7 +304,7 @@ func (c *Client) do(method, path string, data interface{}) ([]byte, int, error) 
 		return nil, -1, err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	if data != nil {
+	if doOptions.data != nil {
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
@@ -339,9 +344,18 @@ func (c *Client) do(method, path string, data interface{}) ([]byte, int, error) 
 	return body, resp.StatusCode, nil
 }
 
-func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool, headers map[string]string, in io.Reader, stdout, stderr io.Writer) error {
-	if (method == "POST" || method == "PUT") && in == nil {
-		in = bytes.NewReader(nil)
+type streamOptions struct {
+	setRawTerminal bool
+	rawJSONStream  bool
+	headers        map[string]string
+	in             io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+}
+
+func (c *Client) stream(method, path string, streamOptions streamOptions) error {
+	if (method == "POST" || method == "PUT") && streamOptions.in == nil {
+		streamOptions.in = bytes.NewReader(nil)
 	}
 	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
 		err := c.checkAPIVersion()
@@ -349,7 +363,7 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 			return err
 		}
 	}
-	req, err := http.NewRequest(method, c.getURL(path), in)
+	req, err := http.NewRequest(method, c.getURL(path), streamOptions.in)
 	if err != nil {
 		return err
 	}
@@ -357,17 +371,17 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	if method == "POST" {
 		req.Header.Set("Content-Type", "plain/text")
 	}
-	for key, val := range headers {
+	for key, val := range streamOptions.headers {
 		req.Header.Set(key, val)
 	}
 	var resp *http.Response
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path
-	if stdout == nil {
-		stdout = ioutil.Discard
+	if streamOptions.stdout == nil {
+		streamOptions.stdout = ioutil.Discard
 	}
-	if stderr == nil {
-		stderr = ioutil.Discard
+	if streamOptions.stderr == nil {
+		streamOptions.stderr = ioutil.Discard
 	}
 	if protocol == "unix" {
 		dial, err := net.Dial(protocol, address)
@@ -397,8 +411,8 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 	if resp.Header.Get("Content-Type") == "application/json" {
 		// if we want to get raw json stream, just copy it back to output
 		// without decoding it
-		if rawJSONStream {
-			_, err = io.Copy(stdout, resp.Body)
+		if streamOptions.rawJSONStream {
+			_, err = io.Copy(streamOptions.stdout, resp.Body)
 			return err
 		}
 		dec := json.NewDecoder(resp.Body)
@@ -410,28 +424,37 @@ func (c *Client) stream(method, path string, setRawTerminal, rawJSONStream bool,
 				return err
 			}
 			if m.Stream != "" {
-				fmt.Fprint(stdout, m.Stream)
+				fmt.Fprint(streamOptions.stdout, m.Stream)
 			} else if m.Progress != "" {
-				fmt.Fprintf(stdout, "%s %s\r", m.Status, m.Progress)
+				fmt.Fprintf(streamOptions.stdout, "%s %s\r", m.Status, m.Progress)
 			} else if m.Error != "" {
 				return errors.New(m.Error)
 			}
 			if m.Status != "" {
-				fmt.Fprintln(stdout, m.Status)
+				fmt.Fprintln(streamOptions.stdout, m.Status)
 			}
 		}
 	} else {
-		if setRawTerminal {
-			_, err = io.Copy(stdout, resp.Body)
+		if streamOptions.setRawTerminal {
+			_, err = io.Copy(streamOptions.stdout, resp.Body)
 		} else {
-			_, err = stdCopy(stdout, stderr, resp.Body)
+			_, err = stdCopy(streamOptions.stdout, streamOptions.stderr, resp.Body)
 		}
 		return err
 	}
 	return nil
 }
 
-func (c *Client) hijack(method, path string, success chan struct{}, setRawTerminal bool, in io.Reader, stderr, stdout io.Writer, data interface{}) error {
+type hijackOptions struct {
+	success        chan struct{}
+	setRawTerminal bool
+	in             io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+	data           interface{}
+}
+
+func (c *Client) hijack(method, path string, hijackOptions hijackOptions) error {
 	if path != "/version" && !c.SkipServerVersionCheck && c.expectedAPIVersion == nil {
 		err := c.checkAPIVersion()
 		if err != nil {
@@ -440,19 +463,19 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	}
 
 	var params io.Reader
-	if data != nil {
-		buf, err := json.Marshal(data)
+	if hijackOptions.data != nil {
+		buf, err := json.Marshal(hijackOptions.data)
 		if err != nil {
 			return err
 		}
 		params = bytes.NewBuffer(buf)
 	}
 
-	if stdout == nil {
-		stdout = ioutil.Discard
+	if hijackOptions.stdout == nil {
+		hijackOptions.stdout = ioutil.Discard
 	}
-	if stderr == nil {
-		stderr = ioutil.Discard
+	if hijackOptions.stderr == nil {
+		hijackOptions.stderr = ioutil.Discard
 	}
 	req, err := http.NewRequest(method, c.getURL(path), params)
 	if err != nil {
@@ -480,9 +503,9 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	clientconn := httputil.NewClientConn(dial, nil)
 	defer clientconn.Close()
 	clientconn.Do(req)
-	if success != nil {
-		success <- struct{}{}
-		<-success
+	if hijackOptions.success != nil {
+		hijackOptions.success <- struct{}{}
+		<-hijackOptions.success
 	}
 	rwc, br := clientconn.Hijack()
 	defer rwc.Close()
@@ -491,23 +514,22 @@ func (c *Client) hijack(method, path string, success chan struct{}, setRawTermin
 	go func() {
 		defer close(exit)
 		var err error
-		if setRawTerminal {
+		if hijackOptions.setRawTerminal {
 			// When TTY is ON, use regular copy
-			_, err = io.Copy(stdout, br)
+			_, err = io.Copy(hijackOptions.stdout, br)
 		} else {
-			_, err = stdCopy(stdout, stderr, br)
+			_, err = stdCopy(hijackOptions.stdout, hijackOptions.stderr, br)
 		}
 		errs <- err
 	}()
 	go func() {
-		var err error
-		if in != nil {
-			_, err = io.Copy(rwc, in)
+		if hijackOptions.in != nil {
+			_, err := io.Copy(rwc, hijackOptions.in)
+			errs <- err
 		}
 		rwc.(interface {
 			CloseWrite() error
 		}).CloseWrite()
-		errs <- err
 	}()
 	<-exit
 	return <-errs
@@ -555,39 +577,49 @@ func queryString(opts interface{}) string {
 		} else if key == "-" {
 			continue
 		}
-		v := value.Field(i)
-		switch v.Kind() {
-		case reflect.Bool:
-			if v.Bool() {
-				items.Add(key, "1")
+		addQueryStringValue(items, key, value.Field(i))
+	}
+	return items.Encode()
+}
+
+func addQueryStringValue(items url.Values, key string, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			items.Add(key, "1")
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() > 0 {
+			items.Add(key, strconv.FormatInt(v.Int(), 10))
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.Float() > 0 {
+			items.Add(key, strconv.FormatFloat(v.Float(), 'f', -1, 64))
+		}
+	case reflect.String:
+		if v.String() != "" {
+			items.Add(key, v.String())
+		}
+	case reflect.Ptr:
+		if !v.IsNil() {
+			if b, err := json.Marshal(v.Interface()); err == nil {
+				items.Add(key, string(b))
 			}
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			if v.Int() > 0 {
-				items.Add(key, strconv.FormatInt(v.Int(), 10))
+		}
+	case reflect.Map:
+		if len(v.MapKeys()) > 0 {
+			if b, err := json.Marshal(v.Interface()); err == nil {
+				items.Add(key, string(b))
 			}
-		case reflect.Float32, reflect.Float64:
-			if v.Float() > 0 {
-				items.Add(key, strconv.FormatFloat(v.Float(), 'f', -1, 64))
-			}
-		case reflect.String:
-			if v.String() != "" {
-				items.Add(key, v.String())
-			}
-		case reflect.Ptr:
-			if !v.IsNil() {
-				if b, err := json.Marshal(v.Interface()); err == nil {
-					items.Add(key, string(b))
-				}
-			}
-		case reflect.Map:
-			if len(v.MapKeys()) > 0 {
-				if b, err := json.Marshal(v.Interface()); err == nil {
-					items.Add(key, string(b))
-				}
+		}
+	case reflect.Array, reflect.Slice:
+		vLen := v.Len()
+		if vLen > 0 {
+			for i := 0; i < vLen; i++ {
+				addQueryStringValue(items, key, v.Index(i))
 			}
 		}
 	}
-	return items.Encode()
 }
 
 // Error represents failures in the API. It represents a failure from the API.
@@ -604,10 +636,13 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("API error (%d): %s", e.Status, e.Message)
 }
 
-func parseEndpoint(endpoint string) (*url.URL, error) {
+func parseEndpoint(endpoint string, tls bool) (*url.URL, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, ErrInvalidEndpoint
+	}
+	if tls {
+		u.Scheme = "https"
 	}
 	if u.Scheme == "tcp" {
 		_, port, err := net.SplitHostPort(u.Host)

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -136,14 +136,15 @@ func TestNewClientInvalidEndpoint(t *testing.T) {
 	}
 }
 
-func TestNewTLSClient2376(t *testing.T) {
+func TestNewTLSClient(t *testing.T) {
 	var tests = []struct {
 		endpoint string
 		expected string
 	}{
 		{"tcp://localhost:2376", "https"},
-		{"tcp://localhost:2375", "http"},
-		{"tcp://localhost:4000", "http"},
+		{"tcp://localhost:2375", "https"},
+		{"tcp://localhost:4000", "https"},
+		{"http://localhost:4000", "https"},
 	}
 
 	for _, tt := range tests {

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -56,7 +56,7 @@ type APIContainers struct {
 // See http://goo.gl/6Y4Gz7 for more details.
 func (c *Client) ListContainers(opts ListContainersOptions) ([]APIContainers, error) {
 	path := "/containers/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, nil)
+	body, _, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -90,6 +90,7 @@ func (p Port) Proto() string {
 type State struct {
 	Running    bool      `json:"Running,omitempty" yaml:"Running,omitempty"`
 	Paused     bool      `json:"Paused,omitempty" yaml:"Paused,omitempty"`
+	Restarting bool      `json:"Restarting,omitempty" yaml:"Restarting,omitempty"`
 	OOMKilled  bool      `json:"OOMKilled,omitempty" yaml:"OOMKilled,omitempty"`
 	Pid        int       `json:"Pid,omitempty" yaml:"Pid,omitempty"`
 	ExitCode   int       `json:"ExitCode,omitempty" yaml:"ExitCode,omitempty"`
@@ -166,7 +167,7 @@ func parsePort(rawPort string) (int, error) {
 }
 
 // Config is the list of configuration options used when creating a container.
-// Config does not the options that are specific to starting a container on a
+// Config does not contain the options that are specific to starting a container on a
 // given host.  Those are contained in HostConfig
 type Config struct {
 	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
@@ -195,6 +196,24 @@ type Config struct {
 	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
 	SecurityOpts    []string            `json:"SecurityOpts,omitempty" yaml:"SecurityOpts,omitempty"`
 	OnBuild         []string            `json:"OnBuild,omitempty" yaml:"OnBuild,omitempty"`
+	Labels          map[string]string   `json:"Labels,omitempty" yaml:"Labels,omitempty"`
+}
+
+// LogConfig defines the log driver type and the configuration for it.
+type LogConfig struct {
+	Type   string            `json:"Type,omitempty" yaml:"Type,omitempty"`
+	Config map[string]string `json:"Config,omitempty" yaml:"Config,omitempty"`
+}
+
+// SwarmNode containers information about which Swarm node the container is on
+type SwarmNode struct {
+	ID     string            `json:"ID,omitempty" yaml:"ID,omitempty"`
+	IP     string            `json:"IP,omitempty" yaml:"IP,omitempty"`
+	Addr   string            `json:"Addr,omitempty" yaml:"Addr,omitempty"`
+	Name   string            `json:"Name,omitempty" yaml:"Name,omitempty"`
+	CPUs   int64             `json:"CPUs,omitempty" yaml:"CPUs,omitempty"`
+	Memory int64             `json:"Memory,omitempty" yaml:"Memory,omitempty"`
+	Labels map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty"`
 }
 
 // Container is the type encompasing everything about a container - its config,
@@ -211,6 +230,8 @@ type Container struct {
 	State  State   `json:"State,omitempty" yaml:"State,omitempty"`
 	Image  string  `json:"Image,omitempty" yaml:"Image,omitempty"`
 
+	Node *SwarmNode `json:"Node,omitempty" yaml:"Node,omitempty"`
+
 	NetworkSettings *NetworkSettings `json:"NetworkSettings,omitempty" yaml:"NetworkSettings,omitempty"`
 
 	SysInitPath    string `json:"SysInitPath,omitempty" yaml:"SysInitPath,omitempty"`
@@ -223,6 +244,28 @@ type Container struct {
 	Volumes    map[string]string `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
 	VolumesRW  map[string]bool   `json:"VolumesRW,omitempty" yaml:"VolumesRW,omitempty"`
 	HostConfig *HostConfig       `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+	ExecIDs    []string          `json:"ExecIDs,omitempty" yaml:"ExecIDs,omitempty"`
+
+	AppArmorProfile string `json:"AppArmorProfile,omitempty" yaml:"AppArmorProfile,omitempty"`
+}
+
+// RenameContainerOptions specify parameters to the RenameContainer function.
+//
+// See http://goo.gl/L00hoj for more details.
+type RenameContainerOptions struct {
+	// ID of container to rename
+	ID string `qs:"-"`
+
+	// New name
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// RenameContainer updates and existing containers name
+//
+// See http://goo.gl/L00hoj for more details.
+func (c *Client) RenameContainer(opts RenameContainerOptions) error {
+	_, _, err := c.do("POST", fmt.Sprintf("/containers/"+opts.ID+"/rename?%s", queryString(opts)), doOptions{})
+	return err
 }
 
 // InspectContainer returns information about a container by its ID.
@@ -230,7 +273,7 @@ type Container struct {
 // See http://goo.gl/CxVuJ5 for more details.
 func (c *Client) InspectContainer(id string) (*Container, error) {
 	path := "/containers/" + id + "/json"
-	body, status, err := c.do("GET", path, nil)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: id}
 	}
@@ -250,7 +293,7 @@ func (c *Client) InspectContainer(id string) (*Container, error) {
 // See http://goo.gl/QkW9sH for more details.
 func (c *Client) ContainerChanges(id string) ([]Change, error) {
 	path := "/containers/" + id + "/changes"
-	body, status, err := c.do("GET", path, nil)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: id}
 	}
@@ -280,13 +323,19 @@ type CreateContainerOptions struct {
 // See http://goo.gl/mErxNp for more details.
 func (c *Client) CreateContainer(opts CreateContainerOptions) (*Container, error) {
 	path := "/containers/create?" + queryString(opts)
-	body, status, err := c.do("POST", path, struct {
-		*Config
-		HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
-	}{
-		opts.Config,
-		opts.HostConfig,
-	})
+	body, status, err := c.do(
+		"POST",
+		path,
+		doOptions{
+			data: struct {
+				*Config
+				HostConfig *HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+			}{
+				opts.Config,
+				opts.HostConfig,
+			},
+		},
+	)
 
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
@@ -343,6 +392,14 @@ func NeverRestart() RestartPolicy {
 	return RestartPolicy{Name: "no"}
 }
 
+// Device represents a device mapping between the Docker host and the
+// container.
+type Device struct {
+	PathOnHost        string `json:"PathOnHost,omitempty" yaml:"PathOnHost,omitempty"`
+	PathInContainer   string `json:"PathInContainer,omitempty" yaml:"PathInContainer,omitempty"`
+	CgroupPermissions string `json:"CgroupPermissions,omitempty" yaml:"CgroupPermissions,omitempty"`
+}
+
 // HostConfig contains the container options related to starting a container on
 // a given host
 type HostConfig struct {
@@ -361,20 +418,23 @@ type HostConfig struct {
 	VolumesFrom     []string               `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
 	NetworkMode     string                 `json:"NetworkMode,omitempty" yaml:"NetworkMode,omitempty"`
 	IpcMode         string                 `json:"IpcMode,omitempty" yaml:"IpcMode,omitempty"`
+	PidMode         string                 `json:"PidMode,omitempty" yaml:"PidMode,omitempty"`
 	RestartPolicy   RestartPolicy          `json:"RestartPolicy,omitempty" yaml:"RestartPolicy,omitempty"`
+	Devices         []Device               `json:"Devices,omitempty" yaml:"Devices,omitempty"`
+	LogConfig       LogConfig              `json:"LogConfig,omitempty" yaml:"LogConfig,omitempty"`
+	ReadonlyRootfs  bool                   `json:"ReadonlyRootfs,omitempty" yaml:"ReadonlyRootfs,omitempty"`
+	SecurityOpt     []string               `json:"SecurityOpt,omitempty" yaml:"SecurityOpt,omitempty"`
+	CgroupParent    string                 `json:"CgroupParent,omitempty" yaml:"CgroupParent,omitempty"`
 }
 
 // StartContainer starts a container, returning an error in case of failure.
 //
 // See http://goo.gl/iM5GYs for more details.
 func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
-	if hostConfig == nil {
-		hostConfig = &HostConfig{}
-	}
 	path := "/containers/" + id + "/start"
-	_, status, err := c.do("POST", path, hostConfig)
+	_, status, err := c.do("POST", path, doOptions{data: hostConfig, forceJSON: true})
 	if status == http.StatusNotFound {
-		return &NoSuchContainer{ID: id}
+		return &NoSuchContainer{ID: id, Err: err}
 	}
 	if status == http.StatusNotModified {
 		return &ContainerAlreadyRunning{ID: id}
@@ -391,7 +451,7 @@ func (c *Client) StartContainer(id string, hostConfig *HostConfig) error {
 // See http://goo.gl/EbcpXt for more details.
 func (c *Client) StopContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/stop?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, nil)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -410,7 +470,7 @@ func (c *Client) StopContainer(id string, timeout uint) error {
 // See http://goo.gl/VOzR2n for more details.
 func (c *Client) RestartContainer(id string, timeout uint) error {
 	path := fmt.Sprintf("/containers/%s/restart?t=%d", id, timeout)
-	_, status, err := c.do("POST", path, nil)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -425,7 +485,7 @@ func (c *Client) RestartContainer(id string, timeout uint) error {
 // See http://goo.gl/AM5t42 for more details.
 func (c *Client) PauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/pause", id)
-	_, status, err := c.do("POST", path, nil)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -435,12 +495,12 @@ func (c *Client) PauseContainer(id string) error {
 	return nil
 }
 
-// UnpauseContainer pauses the given container.
+// UnpauseContainer unpauses the given container.
 //
 // See http://goo.gl/eBrNSL for more details.
 func (c *Client) UnpauseContainer(id string) error {
 	path := fmt.Sprintf("/containers/%s/unpause", id)
-	_, status, err := c.do("POST", path, nil)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: id}
 	}
@@ -469,7 +529,7 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 		args = fmt.Sprintf("?ps_args=%s", psArgs)
 	}
 	path := fmt.Sprintf("/containers/%s/top%s", id, args)
-	body, status, err := c.do("GET", path, nil)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return result, &NoSuchContainer{ID: id}
 	}
@@ -481,6 +541,136 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 		return result, err
 	}
 	return result, nil
+}
+
+// Stats represents container statistics, returned by /containers/<id>/stats.
+//
+// See http://goo.gl/DFMiYD for more details.
+type Stats struct {
+	Read    time.Time `json:"read,omitempty" yaml:"read,omitempty"`
+	Network struct {
+		RxDropped int64 `json:"rx_dropped,omitempty" yaml:"rx_dropped,omitempty"`
+		RxBytes   int64 `json:"rx_bytes,omitempty" yaml:"rx_bytes,omitempty"`
+		RxErrors  int64 `json:"rx_errors,omitempty" yaml:"rx_errors,omitempty"`
+		TxPackets int64 `json:"tx_packets,omitempty" yaml:"tx_packets,omitempty"`
+		TxDropped int64 `json:"tx_dropped,omitempty" yaml:"tx_dropped,omitempty"`
+		RxPackets int64 `json:"rx_packets,omitempty" yaml:"rx_packets,omitempty"`
+		TxErrors  int64 `json:"tx_errors,omitempty" yaml:"tx_errors,omitempty"`
+		TxBytes   int64 `json:"tx_bytes,omitempty" yaml:"tx_bytes,omitempty"`
+	} `json:"network,omitempty" yaml:"network,omitempty"`
+	MemoryStats struct {
+		Stats struct {
+			TotalPgmafault    int64 `json"total_pgmafault,omitempty" yaml:"total_pgmafault,omitempty"`
+			Cache             int64 `json:"cache,omitempty" yaml:"cache,omitempty"`
+			MappedFile        int64 `json:"mapped_file,omitempty" yaml:"mapped_file,omitempty"`
+			TotalInactiveFile int64 `json:"total_inactive_file,omitempty" yaml:"total_inactive_file,omitempty"`
+			Pgpgout           int64 `json:"pgpgout,omitempty" yaml:"pgpgout,omitempty"`
+			Rss               int64 `json:"rss,omitempty" yaml:"rss,omitempty"`
+			TotalMappedFile   int64 `json:"total_mapped_file,omitempty" yaml:"total_mapped_file,omitempty"`
+			Writeback         int64 `json:"writeback,omitempty" yaml:"writeback,omitempty"`
+			Unevictable       int64 `json:"unevictable,omitempty" yaml:"unevictable,omitempty"`
+			Pgpgin            int64 `json:"pgpgin,omitempty" yaml:"pgpgin,omitempty"`
+			TotalUnevictable  int64 `json:"total_unevictable,omitempty" yaml:"total_unevictable,omitempty"`
+			Pgmajfault        int64 `json:"pgmajfault,omitempty" yaml:"pgmajfault,omitempty"`
+			TotalRss          int64 `json:"total_rss,omitempty" yaml:"total_rss,omitempty"`
+			TotalRssHuge      int64 `json:"total_rss_huge,omitempty" yaml:"total_rss_huge,omitempty"`
+			TotalWriteback    int64 `json:"total_writeback,omitempty" yaml:"total_writeback,omitempty"`
+			TotalInactiveAnon int64 `json:"total_inactive_anon,omitempty" yaml:"total_inactive_anon,omitempty"`
+			RssHuge           int64 `json:"rss_huge,omitempty" yaml:"rss_huge,omitempty"`
+			// TODO(pedge): this kills the whole thing, why? commenting out for now
+			//HierarchicalMemoryLimit int64 `json:"hierarchical_memory_limit,omitempty" yaml:"hierarchical_memory_limit,omitempty"`
+			TotalPgfault    int64 `json:"total_pgfault,omitempty" yaml:"total_pgfault,omitempty"`
+			TotalActiveFile int64 `json:"total_active_file,omitempty" yaml:"total_active_file,omitempty"`
+			ActiveAnon      int64 `json:"active_anon,omitempty" yaml:"active_anon,omitempty"`
+			TotalActiveAnon int64 `json:"total_active_anon,omitempty" yaml:"total_active_anon,omitempty"`
+			TotalPgpgout    int64 `json:"total_pgpgout,omitempty" yaml:"total_pgpgout,omitempty"`
+			TotalCache      int64 `json:"total_cache,omitempty" yaml:"total_cache,omitempty"`
+			InactiveAnon    int64 `json:"inactive_anon,omitempty" yaml:"inactive_anon,omitempty"`
+			ActiveFile      int64 `json:"active_file,omitempty" yaml:"active_file,omitempty"`
+			Pgfault         int64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
+			InactiveFile    int64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
+			TotalPgpgin     int64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
+		} `json:"stats,omitempty" yaml:"stats,omitempty"`
+		MaxUsage int64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty"`
+		Usage    int64 `json:"usage,omitempty" yaml:"usage,omitempty"`
+		Failcnt  int64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty"`
+		Limit    int64 `json:"limit,omitempty" yaml:"limit,omitempty"`
+	} `json:"memory_stats,omitempty" yaml:"memory_stats,omitempty"`
+	// TODO(pedge): this is in the docker docs, but no data
+	//BlkioStats string `json:"blkio_stats,omitempty" yaml:"blkio_stats,omitempty"`
+	CPUStats struct {
+		CPUUsage struct {
+			PercpuUsage       []int64 `json:"percpu_usage,omitempty" yaml:"percpu_usage,omitempty"`
+			UsageInUsermode   int64   `json:"usage_in_usermode,omitempty" yaml:"usage_in_usermode,omitempty"`
+			TotalUsage        int64   `json:"total_usage,omitempty" yaml:"total_usage,omitempty"`
+			UsageInKernelmode int64   `json:"usage_in_kernelmode,omitempty" yaml:"usage_in_kernelmode,omitempty"`
+		} `json:"cpu_usage,omitempty" yaml:"cpu_usage,omitempty"`
+		SystemCPUUsage int64 `json:"system_cpu_usage,omitempty" yaml:"system_cpu_usage,omitempty"`
+		// TODO(pedge): this is in the docker docs, but no data
+		//ThrottlingData string `json:"throttling_data,omitempty" yaml:"throttling_data,omitempty"`
+	} `json:"cpu_stats,omitempty" yaml:"cpu_stats,omitempty"`
+}
+
+// StatsOptions specify parameters to the Stats function.
+//
+// See http://goo.gl/DFMiYD for more details.
+type StatsOptions struct {
+	ID    string
+	Stats chan<- *Stats
+}
+
+// Stats sends container statistics for the given container to the given channel.
+//
+// This function is blocking, similar to a streaming call for logs, and should be run
+// on a separate goroutine from the caller. Note that this function will block until
+// the given container is removed, not just exited. When finished, this function
+// will close the given channel.
+//
+// See http://goo.gl/DFMiYD for more details.
+func (c *Client) Stats(opts StatsOptions) (retErr error) {
+	errC := make(chan error, 1)
+	readCloser, writeCloser := io.Pipe()
+
+	defer func() {
+		close(opts.Stats)
+		if err := <-errC; err != nil && retErr == nil {
+			retErr = err
+		}
+		if err := readCloser.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	go func() {
+		err := c.stream("GET", fmt.Sprintf("/containers/%s/stats", opts.ID), streamOptions{
+			rawJSONStream: true,
+			stdout:        writeCloser,
+		})
+		if err != nil {
+			dockerError, ok := err.(*Error)
+			if ok {
+				if dockerError.Status == http.StatusNotFound {
+					err = &NoSuchContainer{ID: opts.ID}
+				}
+			}
+		}
+		if closeErr := writeCloser.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		errC <- err
+		close(errC)
+	}()
+
+	decoder := json.NewDecoder(readCloser)
+	stats := new(Stats)
+	for err := decoder.Decode(&stats); err != io.EOF; err = decoder.Decode(stats) {
+		if err != nil {
+			return err
+		}
+		opts.Stats <- stats
+		stats = new(Stats)
+	}
+	return nil
 }
 
 // KillContainerOptions represents the set of options that can be used in a
@@ -501,7 +691,7 @@ type KillContainerOptions struct {
 // See http://goo.gl/TFkECx for more details.
 func (c *Client) KillContainer(opts KillContainerOptions) error {
 	path := "/containers/" + opts.ID + "/kill" + "?" + queryString(opts)
-	_, status, err := c.do("POST", path, nil)
+	_, status, err := c.do("POST", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.ID}
 	}
@@ -532,7 +722,7 @@ type RemoveContainerOptions struct {
 // See http://goo.gl/ZB83ji for more details.
 func (c *Client) RemoveContainer(opts RemoveContainerOptions) error {
 	path := "/containers/" + opts.ID + "?" + queryString(opts)
-	_, status, err := c.do("DELETE", path, nil)
+	_, status, err := c.do("DELETE", path, doOptions{})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.ID}
 	}
@@ -561,7 +751,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 		return &NoSuchContainer{ID: opts.Container}
 	}
 	url := fmt.Sprintf("/containers/%s/copy", opts.Container)
-	body, status, err := c.do("POST", url, opts)
+	body, status, err := c.do("POST", url, doOptions{data: opts})
 	if status == http.StatusNotFound {
 		return &NoSuchContainer{ID: opts.Container}
 	}
@@ -577,7 +767,7 @@ func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 //
 // See http://goo.gl/J88DHU for more details.
 func (c *Client) WaitContainer(id string) (int, error) {
-	body, status, err := c.do("POST", "/containers/"+id+"/wait", nil)
+	body, status, err := c.do("POST", "/containers/"+id+"/wait", doOptions{})
 	if status == http.StatusNotFound {
 		return 0, &NoSuchContainer{ID: id}
 	}
@@ -609,7 +799,7 @@ type CommitContainerOptions struct {
 // See http://goo.gl/Jn8pe8 for more details.
 func (c *Client) CommitContainer(opts CommitContainerOptions) (*Image, error) {
 	path := "/commit?" + queryString(opts)
-	body, status, err := c.do("POST", path, opts.Run)
+	body, status, err := c.do("POST", path, doOptions{data: opts.Run})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: opts.Container}
 	}
@@ -668,7 +858,13 @@ func (c *Client) AttachToContainer(opts AttachToContainerOptions) error {
 		return &NoSuchContainer{ID: opts.Container}
 	}
 	path := "/containers/" + opts.Container + "/attach?" + queryString(opts)
-	return c.hijack("POST", path, opts.Success, opts.RawTerminal, opts.InputStream, opts.ErrorStream, opts.OutputStream, nil)
+	return c.hijack("POST", path, hijackOptions{
+		success:        opts.Success,
+		setRawTerminal: opts.RawTerminal,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+	})
 }
 
 // LogsOptions represents the set of options used when getting logs from a
@@ -700,7 +896,11 @@ func (c *Client) Logs(opts LogsOptions) error {
 		opts.Tail = "all"
 	}
 	path := "/containers/" + opts.Container + "/logs?" + queryString(opts)
-	return c.stream("GET", path, opts.RawTerminal, false, nil, nil, opts.OutputStream, opts.ErrorStream)
+	return c.stream("GET", path, streamOptions{
+		setRawTerminal: opts.RawTerminal,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+	})
 }
 
 // ResizeContainerTTY resizes the terminal to the given height and width.
@@ -708,7 +908,7 @@ func (c *Client) ResizeContainerTTY(id string, height, width int) error {
 	params := make(url.Values)
 	params.Set("h", strconv.Itoa(height))
 	params.Set("w", strconv.Itoa(width))
-	_, _, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), nil)
+	_, _, err := c.do("POST", "/containers/"+id+"/resize?"+params.Encode(), doOptions{})
 	return err
 }
 
@@ -730,15 +930,22 @@ func (c *Client) ExportContainer(opts ExportContainerOptions) error {
 		return &NoSuchContainer{ID: opts.ID}
 	}
 	url := fmt.Sprintf("/containers/%s/export", opts.ID)
-	return c.stream("GET", url, true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", url, streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // NoSuchContainer is the error returned when a given container does not exist.
 type NoSuchContainer struct {
-	ID string
+	ID  string
+	Err error
 }
 
 func (err *NoSuchContainer) Error() string {
+	if err.Err != nil {
+		return err.Err.Error()
+	}
 	return "No such container: " + err.ID
 }
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -7,6 +7,7 @@ package docker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -154,6 +155,7 @@ func TestListContainersFailure(t *testing.T) {
 func TestInspectContainer(t *testing.T) {
 	jsonContainer := `{
              "Id": "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2",
+             "AppArmorProfile": "Profile",
              "Created": "2013-05-07T14:51:42.087658+02:00",
              "Path": "date",
              "Args": [],
@@ -175,7 +177,10 @@ func TestInspectContainer(t *testing.T) {
                      ],
                      "Image": "base",
                      "Volumes": {},
-                     "VolumesFrom": ""
+                     "VolumesFrom": "",
+                     "SecurityOpt": [
+                         "label:user:USER"
+                      ]
              },
              "State": {
                      "Running": false,
@@ -184,6 +189,21 @@ func TestInspectContainer(t *testing.T) {
                      "StartedAt": "2013-05-07T14:51:42.087658+02:00",
                      "Ghost": false
              },
+             "Node": {
+                  "ID": "4I4E:QR4I:Z733:QEZK:5X44:Q4T7:W2DD:JRDY:KB2O:PODO:Z5SR:XRB6",
+                  "IP": "192.168.99.105",
+                  "Addra": "192.168.99.105:2376",
+                  "Name": "node-01",
+                  "Cpus": 4,
+                  "Memory": 1048436736,
+                  "Labels": {
+                      "executiondriver": "native-0.2",
+                      "kernelversion": "3.18.5-tinycore64",
+                      "operatingsystem": "Boot2Docker 1.5.0 (TCL 5.4); master : a66bce5 - Tue Feb 10 23:31:27 UTC 2015",
+                      "provider": "virtualbox",
+                      "storagedriver": "aufs"
+                  }
+              },
              "Image": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
              "NetworkSettings": {
                      "IpAddress": "",
@@ -209,7 +229,8 @@ func TestInspectContainer(t *testing.T) {
                  ]
                },
                "Links": null,
-               "PublishAllPorts": false
+               "PublishAllPorts": false,
+               "CgroupParent": "/mesos"
              }
 }`
 	var expected Container
@@ -511,12 +532,17 @@ func TestStartContainerNilHostConfig(t *testing.T) {
 	if contentType := req.Header.Get("Content-Type"); contentType != expectedContentType {
 		t.Errorf("StartContainer(%q): Wrong content-type in request. Want %q. Got %q.", id, expectedContentType, contentType)
 	}
+	var buf [4]byte
+	req.Body.Read(buf[:])
+	if string(buf[:]) != "null" {
+		t.Errorf("Startcontainer(%q): Wrong body. Want null. Got %s", buf[:])
+	}
 }
 
 func TestStartContainerNotFound(t *testing.T) {
 	client := newTestClient(&FakeRoundTripper{message: "no such container", status: http.StatusNotFound})
 	err := client.StartContainer("a2344", &HostConfig{})
-	expected := &NoSuchContainer{ID: "a2344"}
+	expected := &NoSuchContainer{ID: "a2344", Err: err.(*NoSuchContainer).Err}
 	if !reflect.DeepEqual(err, expected) {
 		t.Errorf("StartContainer: Wrong error returned. Want %#v. Got %#v.", expected, err)
 	}
@@ -1287,6 +1313,14 @@ func TestNoSuchContainerError(t *testing.T) {
 	}
 }
 
+func TestNoSuchContainerErrorMessage(t *testing.T) {
+	var err = &NoSuchContainer{ID: "i345", Err: errors.New("some advanced error info")}
+	expected := "some advanced error info"
+	if got := err.Error(); got != expected {
+		t.Errorf("NoSuchContainer: wrong message. Want %q. Got %q.", expected, got)
+	}
+}
+
 func TestExportContainer(t *testing.T) {
 	content := "exported container tar content"
 	out := stdoutMock{bytes.NewBufferString(content)}
@@ -1311,7 +1345,7 @@ func TestExportContainerViaUnixSocket(t *testing.T) {
 	tempSocket := tempfile("export_socket")
 	defer os.Remove(tempSocket)
 	endpoint := "unix://" + tempSocket
-	u, _ := parseEndpoint(endpoint)
+	u, _ := parseEndpoint(endpoint, false)
 	client := Client{
 		HTTPClient:             http.DefaultClient,
 		endpoint:               endpoint,
@@ -1520,5 +1554,224 @@ func TestTopContainerWithPsArgs(t *testing.T) {
 	expectedURI := "/containers/abef348/top?ps_args=aux"
 	if !strings.HasSuffix(fakeRT.requests[0].URL.String(), expectedURI) {
 		t.Errorf("TopContainer: Expected URI to have %q. Got %q.", expectedURI, fakeRT.requests[0].URL.String())
+	}
+}
+
+func TestStats(t *testing.T) {
+	jsonStats1 := `{
+       "read" : "2015-01-08T22:57:31.547920715Z",
+       "network" : {
+          "rx_dropped" : 0,
+          "rx_bytes" : 648,
+          "rx_errors" : 0,
+          "tx_packets" : 8,
+          "tx_dropped" : 0,
+          "rx_packets" : 8,
+          "tx_errors" : 0,
+          "tx_bytes" : 648
+       },
+       "memory_stats" : {
+          "stats" : {
+             "total_pgmajfault" : 0,
+             "cache" : 0,
+             "mapped_file" : 0,
+             "total_inactive_file" : 0,
+             "pgpgout" : 414,
+             "rss" : 6537216,
+             "total_mapped_file" : 0,
+             "writeback" : 0,
+             "unevictable" : 0,
+             "pgpgin" : 477,
+             "total_unevictable" : 0,
+             "pgmajfault" : 0,
+             "total_rss" : 6537216,
+             "total_rss_huge" : 6291456,
+             "total_writeback" : 0,
+             "total_inactive_anon" : 0,
+             "rss_huge" : 6291456,
+             "total_pgfault" : 964,
+             "total_active_file" : 0,
+             "active_anon" : 6537216,
+             "total_active_anon" : 6537216,
+             "total_pgpgout" : 414,
+             "total_cache" : 0,
+             "inactive_anon" : 0,
+             "active_file" : 0,
+             "pgfault" : 964,
+             "inactive_file" : 0,
+             "total_pgpgin" : 477
+          },
+          "max_usage" : 6651904,
+          "usage" : 6537216,
+          "failcnt" : 0,
+          "limit" : 67108864
+       },
+       "cpu_stats" : {
+          "cpu_usage" : {
+             "percpu_usage" : [
+                16970827,
+                1839451,
+                7107380,
+                10571290
+             ],
+             "usage_in_usermode" : 10000000,
+             "total_usage" : 36488948,
+             "usage_in_kernelmode" : 20000000
+          },
+          "system_cpu_usage" : 20091722000000000
+       }
+    }`
+	// 1 second later, cache is 100
+	jsonStats2 := `{
+       "read" : "2015-01-08T22:57:32.547920715Z",
+       "network" : {
+          "rx_dropped" : 0,
+          "rx_bytes" : 648,
+          "rx_errors" : 0,
+          "tx_packets" : 8,
+          "tx_dropped" : 0,
+          "rx_packets" : 8,
+          "tx_errors" : 0,
+          "tx_bytes" : 648
+       },
+       "memory_stats" : {
+          "stats" : {
+             "total_pgmajfault" : 0,
+             "cache" : 100,
+             "mapped_file" : 0,
+             "total_inactive_file" : 0,
+             "pgpgout" : 414,
+             "rss" : 6537216,
+             "total_mapped_file" : 0,
+             "writeback" : 0,
+             "unevictable" : 0,
+             "pgpgin" : 477,
+             "total_unevictable" : 0,
+             "pgmajfault" : 0,
+             "total_rss" : 6537216,
+             "total_rss_huge" : 6291456,
+             "total_writeback" : 0,
+             "total_inactive_anon" : 0,
+             "rss_huge" : 6291456,
+             "total_pgfault" : 964,
+             "total_active_file" : 0,
+             "active_anon" : 6537216,
+             "total_active_anon" : 6537216,
+             "total_pgpgout" : 414,
+             "total_cache" : 0,
+             "inactive_anon" : 0,
+             "active_file" : 0,
+             "pgfault" : 964,
+             "inactive_file" : 0,
+             "total_pgpgin" : 477
+          },
+          "max_usage" : 6651904,
+          "usage" : 6537216,
+          "failcnt" : 0,
+          "limit" : 67108864
+       },
+       "cpu_stats" : {
+          "cpu_usage" : {
+             "percpu_usage" : [
+                16970827,
+                1839451,
+                7107380,
+                10571290
+             ],
+             "usage_in_usermode" : 10000000,
+             "total_usage" : 36488948,
+             "usage_in_kernelmode" : 20000000
+          },
+          "system_cpu_usage" : 20091722000000000
+       }
+    }`
+	var expected1 Stats
+	var expected2 Stats
+	err := json.Unmarshal([]byte(jsonStats1), &expected1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal([]byte(jsonStats2), &expected2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := "4fa6e0f0"
+
+	var req http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(jsonStats1))
+		w.Write([]byte(jsonStats2))
+		req = *r
+	}))
+	defer server.Close()
+	client, _ := NewClient(server.URL)
+	client.SkipServerVersionCheck = true
+	errC := make(chan error, 1)
+	statsC := make(chan *Stats)
+	go func() {
+		errC <- client.Stats(StatsOptions{id, statsC})
+		close(errC)
+	}()
+	var resultStats []*Stats
+	for {
+		stats, ok := <-statsC
+		if !ok {
+			break
+		}
+		resultStats = append(resultStats, stats)
+	}
+	err = <-errC
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resultStats) != 2 {
+		t.Fatalf("Stats: Expected 2 results. Got %d.", len(resultStats))
+	}
+	if !reflect.DeepEqual(resultStats[0], &expected1) {
+		t.Errorf("Stats: Expected:\n%+v\nGot:\n%+v", expected1, resultStats[0])
+	}
+	if !reflect.DeepEqual(resultStats[1], &expected2) {
+		t.Errorf("Stats: Expected:\n%+v\nGot:\n%+v", expected2, resultStats[1])
+	}
+	if req.Method != "GET" {
+		t.Errorf("Stats: wrong HTTP method. Want GET. Got %s.", req.Method)
+	}
+	u, _ := url.Parse(client.getURL("/containers/" + id + "/stats"))
+	if req.URL.Path != u.Path {
+		t.Errorf("Stats: wrong HTTP path. Want %q. Got %q.", u.Path, req.URL.Path)
+	}
+}
+
+func TestStatsContainerNotFound(t *testing.T) {
+	client := newTestClient(&FakeRoundTripper{message: "no such container", status: http.StatusNotFound})
+	statsC := make(chan *Stats)
+	err := client.Stats(StatsOptions{"abef348", statsC})
+	expected := &NoSuchContainer{ID: "abef348"}
+	if !reflect.DeepEqual(err, expected) {
+		t.Errorf("Stats: Wrong error returned. Want %#v. Got %#v.", expected, err)
+	}
+}
+
+func TestRenameContainer(t *testing.T) {
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := RenameContainerOptions{ID: "something_old", Name: "something_new"}
+	err := client.RenameContainer(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "POST" {
+		t.Errorf("RenameContainer: wrong HTTP method. Want %q. Got %q.", "POST", req.Method)
+	}
+	expectedURL, _ := url.Parse(client.getURL("/containers/something_old/rename?name=something_new"))
+	if gotPath := req.URL.Path; gotPath != expectedURL.Path {
+		t.Errorf("RenameContainer: Wrong path in request. Want %q. Got %q.", expectedURL.Path, gotPath)
+	}
+	expectedValues := expectedURL.Query()["name"]
+	actualValues := req.URL.Query()["name"]
+	if len(actualValues) != 1 || expectedValues[0] != actualValues[0] {
+		t.Errorf("RenameContainer: Wrong params in request. Want %q. Got %q.", expectedValues, actualValues)
 	}
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -90,7 +90,7 @@ type ExecInspect struct {
 // See http://goo.gl/8izrzI for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
-	body, status, err := c.do("POST", path, opts)
+	body, status, err := c.do("POST", path, doOptions{data: opts})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchContainer{ID: opts.Container}
 	}
@@ -119,7 +119,7 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 	path := fmt.Sprintf("/exec/%s/start", id)
 
 	if opts.Detach {
-		_, status, err := c.do("POST", path, opts)
+		_, status, err := c.do("POST", path, doOptions{data: opts})
 		if status == http.StatusNotFound {
 			return &NoSuchExec{ID: id}
 		}
@@ -129,7 +129,14 @@ func (c *Client) StartExec(id string, opts StartExecOptions) error {
 		return nil
 	}
 
-	return c.hijack("POST", path, opts.Success, opts.RawTerminal, opts.InputStream, opts.ErrorStream, opts.OutputStream, opts)
+	return c.hijack("POST", path, hijackOptions{
+		success:        opts.Success,
+		setRawTerminal: opts.RawTerminal,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+		data:           opts,
+	})
 }
 
 // ResizeExecTTY resizes the tty session used by the exec command id. This API
@@ -143,7 +150,7 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 	params.Set("w", strconv.Itoa(width))
 
 	path := fmt.Sprintf("/exec/%s/resize?%s", id, params.Encode())
-	_, _, err := c.do("POST", path, nil)
+	_, _, err := c.do("POST", path, doOptions{})
 	return err
 }
 
@@ -152,7 +159,7 @@ func (c *Client) ResizeExecTTY(id string, height, width int) error {
 // See http://goo.gl/ypQULN for more details
 func (c *Client) InspectExec(id string) (*ExecInspect, error) {
 	path := fmt.Sprintf("/exec/%s/json", id)
-	body, status, err := c.do("GET", path, nil)
+	body, status, err := c.do("GET", path, doOptions{})
 	if status == http.StatusNotFound {
 		return nil, &NoSuchExec{ID: id}
 	}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -26,6 +26,7 @@ type APIImages struct {
 	Size        int64    `json:"Size,omitempty" yaml:"Size,omitempty"`
 	VirtualSize int64    `json:"VirtualSize,omitempty" yaml:"VirtualSize,omitempty"`
 	ParentID    string   `json:"ParentId,omitempty" yaml:"ParentId,omitempty"`
+	RepoDigests []string `json:"RepoDigests,omitempty" yaml:"RepoDigests,omitempty"`
 }
 
 // Image is the type representing a docker image and its various properties
@@ -71,10 +72,11 @@ type ImagePre012 struct {
 
 // ListImagesOptions specify parameters to the ListImages function.
 //
-// See http://goo.gl/2rOLFF for more details.
+// See http://goo.gl/HRVN1Z for more details.
 type ListImagesOptions struct {
 	All     bool
 	Filters map[string][]string
+	Digests bool
 }
 
 var (
@@ -92,14 +94,19 @@ var (
 	// ErrMultipleContexts is the error returned when both a ContextDir and
 	// InputStream are provided in BuildImageOptions
 	ErrMultipleContexts = errors.New("image build may not be provided BOTH context dir and input stream")
+
+	// ErrMustSpecifyNames is the error rreturned when the Names field on
+	// ExportImagesOptions is nil or empty
+	ErrMustSpecifyNames = errors.New("must specify at least one name to export")
 )
 
 // ListImages returns the list of available images in the server.
 //
-// See http://goo.gl/2rOLFF for more details.
+// See http://goo.gl/HRVN1Z for more details.
 func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
+	// TODO(pedge): what happens if we specify the digest parameter when using API Version <1.18?
 	path := "/images/json?" + queryString(opts)
-	body, _, err := c.do("GET", path, nil)
+	body, _, err := c.do("GET", path, doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +122,7 @@ func (c *Client) ListImages(opts ListImagesOptions) ([]APIImages, error) {
 //
 // See http://goo.gl/2oJmNs for more details.
 func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/history", nil)
+	body, status, err := c.do("GET", "/images/"+name+"/history", doOptions{})
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}
@@ -134,7 +141,7 @@ func (c *Client) ImageHistory(name string) ([]ImageHistory, error) {
 //
 // See http://goo.gl/znj0wM for more details.
 func (c *Client) RemoveImage(name string) error {
-	_, status, err := c.do("DELETE", "/images/"+name, nil)
+	_, status, err := c.do("DELETE", "/images/"+name, doOptions{})
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
@@ -156,7 +163,7 @@ type RemoveImageOptions struct {
 // See http://goo.gl/znj0wM for more details.
 func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error {
 	uri := fmt.Sprintf("/images/%s?%s", name, queryString(&opts))
-	_, status, err := c.do("DELETE", uri, nil)
+	_, status, err := c.do("DELETE", uri, doOptions{})
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
@@ -167,7 +174,7 @@ func (c *Client) RemoveImageExtended(name string, opts RemoveImageOptions) error
 //
 // See http://goo.gl/Q112NY for more details.
 func (c *Client) InspectImage(name string) (*Image, error) {
-	body, status, err := c.do("GET", "/images/"+name+"/json", nil)
+	body, status, err := c.do("GET", "/images/"+name+"/json", doOptions{})
 	if status == http.StatusNotFound {
 		return nil, ErrNoSuchImage
 	}
@@ -178,7 +185,7 @@ func (c *Client) InspectImage(name string) (*Image, error) {
 	var image Image
 
 	// if the caller elected to skip checking the server's version, assume it's the latest
-	if c.SkipServerVersionCheck || c.expectedAPIVersion.GreaterThanOrEqualTo(apiVersion1_12) {
+	if c.SkipServerVersionCheck || c.expectedAPIVersion.GreaterThanOrEqualTo(apiVersion112) {
 		err = json.Unmarshal(body, &image)
 		if err != nil {
 			return nil, err
@@ -223,21 +230,6 @@ type PushImageOptions struct {
 	RawJSONStream bool      `qs:"-"`
 }
 
-// AuthConfiguration represents authentication options to use in the PushImage
-// method. It represents the authentication in the Docker index server.
-type AuthConfiguration struct {
-	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
-	Email         string `json:"email,omitempty"`
-	ServerAddress string `json:"serveraddress,omitempty"`
-}
-
-// AuthConfigurations represents authentication options to use for the
-// PushImage method accommodating the new X-Registry-Config header
-type AuthConfigurations struct {
-	Configs map[string]AuthConfiguration `json:"configs"`
-}
-
 // PushImage pushes an image to a remote registry, logging progress to w.
 //
 // An empty instance of AuthConfiguration may be used for unauthenticated
@@ -251,8 +243,12 @@ func (c *Client) PushImage(opts PushImageOptions, auth AuthConfiguration) error 
 	name := opts.Name
 	opts.Name = ""
 	path := "/images/" + name + "/push?" + queryString(&opts)
-	headers := headersWithAuth(auth)
-	return c.stream("POST", path, true, opts.RawJSONStream, headers, nil, opts.OutputStream, nil)
+	return c.stream("POST", path, streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  opts.RawJSONStream,
+		headers:        headersWithAuth(auth),
+		stdout:         opts.OutputStream,
+	})
 }
 
 // PullImageOptions present the set of options available for pulling an image
@@ -267,7 +263,7 @@ type PullImageOptions struct {
 	RawJSONStream bool      `qs:"-"`
 }
 
-// PullImage pulls an image from a remote registry, logging progress to w.
+// PullImage pulls an image from a remote registry, logging progress to opts.OutputStream.
 //
 // See http://goo.gl/ACyYNS for more details.
 func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error {
@@ -281,7 +277,13 @@ func (c *Client) PullImage(opts PullImageOptions, auth AuthConfiguration) error 
 
 func (c *Client) createImage(qs string, headers map[string]string, in io.Reader, w io.Writer, rawJSONStream bool) error {
 	path := "/images/create?" + qs
-	return c.stream("POST", path, true, rawJSONStream, headers, in, w, nil)
+	return c.stream("POST", path, streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  rawJSONStream,
+		headers:        headers,
+		in:             in,
+		stdout:         w,
+	})
 }
 
 // LoadImageOptions represents the options for LoadImage Docker API Call
@@ -295,7 +297,10 @@ type LoadImageOptions struct {
 //
 // See http://goo.gl/Y8NNCq for more details.
 func (c *Client) LoadImage(opts LoadImageOptions) error {
-	return c.stream("POST", "/images/load", true, false, nil, opts.InputStream, nil, nil)
+	return c.stream("POST", "/images/load", streamOptions{
+		setRawTerminal: true,
+		in:             opts.InputStream,
+	})
 }
 
 // ExportImageOptions represent the options for ExportImage Docker API call
@@ -310,7 +315,31 @@ type ExportImageOptions struct {
 //
 // See http://goo.gl/mi6kvk for more details.
 func (c *Client) ExportImage(opts ExportImageOptions) error {
-	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), true, false, nil, nil, opts.OutputStream, nil)
+	return c.stream("GET", fmt.Sprintf("/images/%s/get", opts.Name), streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
+}
+
+// ExportImagesOptions represent the options for ExportImages Docker API call
+//
+// See http://goo.gl/YeZzQK for more details.
+type ExportImagesOptions struct {
+	Names        []string
+	OutputStream io.Writer `qs:"-"`
+}
+
+// ExportImages exports one or more images (as a tar file) into the stream
+//
+// See http://goo.gl/YeZzQK for more details.
+func (c *Client) ExportImages(opts ExportImagesOptions) error {
+	if opts.Names == nil || len(opts.Names) == 0 {
+		return ErrMustSpecifyNames
+	}
+	return c.stream("GET", "/images/get?"+queryString(&opts), streamOptions{
+		setRawTerminal: true,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // ImportImageOptions present the set of informations available for importing
@@ -358,8 +387,13 @@ type BuildImageOptions struct {
 	Dockerfile          string             `qs:"dockerfile"`
 	NoCache             bool               `qs:"nocache"`
 	SuppressOutput      bool               `qs:"q"`
+	Pull                bool               `qs:"pull"`
 	RmTmpContainer      bool               `qs:"rm"`
 	ForceRmTmpContainer bool               `qs:"forcerm"`
+	Memory              int64              `qs:"memory"`
+	Memswap             int64              `qs:"memswap"`
+	CPUShares           int64              `qs:"cpushares"`
+	CPUSetCPUs          string             `qs:"cpusetcpus"`
 	InputStream         io.Reader          `qs:"-"`
 	OutputStream        io.Writer          `qs:"-"`
 	RawJSONStream       bool               `qs:"-"`
@@ -372,7 +406,7 @@ type BuildImageOptions struct {
 // BuildImage builds an image from a tarball's url or a Dockerfile in the input
 // stream.
 //
-// See http://goo.gl/wRsW76 for more details.
+// See http://goo.gl/7nuGXa for more details.
 func (c *Client) BuildImage(opts BuildImageOptions) error {
 	if opts.OutputStream == nil {
 		return ErrMissingOutputStream
@@ -397,8 +431,13 @@ func (c *Client) BuildImage(opts BuildImageOptions) error {
 		}
 	}
 
-	return c.stream("POST", fmt.Sprintf("/build?%s",
-		queryString(&opts)), true, opts.RawJSONStream, headers, opts.InputStream, opts.OutputStream, nil)
+	return c.stream("POST", fmt.Sprintf("/build?%s", queryString(&opts)), streamOptions{
+		setRawTerminal: true,
+		rawJSONStream:  opts.RawJSONStream,
+		headers:        headers,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+	})
 }
 
 // TagImageOptions present the set of options to tag an image.
@@ -418,7 +457,8 @@ func (c *Client) TagImage(name string, opts TagImageOptions) error {
 		return ErrNoSuchImage
 	}
 	_, status, err := c.do("POST", fmt.Sprintf("/images/"+name+"/tag?%s",
-		queryString(&opts)), nil)
+		queryString(&opts)), doOptions{})
+
 	if status == http.StatusNotFound {
 		return ErrNoSuchImage
 	}
@@ -468,7 +508,7 @@ type APIImageSearch struct {
 //
 // See http://goo.gl/xI5lLZ for more details.
 func (c *Client) SearchImages(term string) ([]APIImageSearch, error) {
-	body, _, err := c.do("GET", "/images/search?term="+term, nil)
+	body, _, err := c.do("GET", "/images/search?term="+term, doOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,7 @@ import (
 
 func newTestClient(rt *FakeRoundTripper) Client {
 	endpoint := "http://localhost:4243"
-	u, _ := parseEndpoint("http://localhost:4243")
+	u, _ := parseEndpoint("http://localhost:4243", false)
 	client := Client{
 		HTTPClient:             &http.Client{Transport: rt},
 		endpoint:               endpoint,
@@ -655,8 +655,13 @@ func TestBuildImageParameters(t *testing.T) {
 		Name:                "testImage",
 		NoCache:             true,
 		SuppressOutput:      true,
+		Pull:                true,
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,
+		Memory:              1024,
+		Memswap:             2048,
+		CPUShares:           10,
+		CPUSetCPUs:          "0-3",
 		InputStream:         &buf,
 		OutputStream:        &buf,
 	}
@@ -665,7 +670,18 @@ func TestBuildImageParameters(t *testing.T) {
 		t.Fatal(err)
 	}
 	req := fakeRT.requests[0]
-	expected := map[string][]string{"t": {opts.Name}, "nocache": {"1"}, "q": {"1"}, "rm": {"1"}, "forcerm": {"1"}}
+	expected := map[string][]string{
+		"t":          {opts.Name},
+		"nocache":    {"1"},
+		"q":          {"1"},
+		"pull":       {"1"},
+		"rm":         {"1"},
+		"forcerm":    {"1"},
+		"memory":     {"1024"},
+		"memswap":    {"2048"},
+		"cpushares":  {"10"},
+		"cpusetcpus": {"0-3"},
+	}
 	got := map[string][]string(req.URL.Query())
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("BuildImage: wrong query string. Want %#v. Got %#v.", expected, got)
@@ -857,6 +873,40 @@ func TestExportImage(t *testing.T) {
 	expectedPath := "/images/testimage/get"
 	if req.URL.Path != expectedPath {
 		t.Errorf("ExportIMage: wrong path. Expected %q. Got %q.", expectedPath, req.URL.Path)
+	}
+}
+
+func TestExportImages(t *testing.T) {
+	var buf bytes.Buffer
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := ExportImagesOptions{Names: []string{"testimage1", "testimage2:latest"}, OutputStream: &buf}
+	err := client.ExportImages(opts)
+	if nil != err {
+		t.Error(err)
+	}
+	req := fakeRT.requests[0]
+	if req.Method != "GET" {
+		t.Errorf("ExportImage: wrong method. Expected %q. Got %q.", "GET", req.Method)
+	}
+	expected := "http://localhost:4243/images/get?names=testimage1&names=testimage2%3Alatest"
+	got := req.URL.String()
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ExportIMage: wrong path. Expected %q. Got %q.", expected, got)
+	}
+}
+
+func TestExportImagesNoNames(t *testing.T) {
+	var buf bytes.Buffer
+	fakeRT := &FakeRoundTripper{message: "", status: http.StatusOK}
+	client := newTestClient(fakeRT)
+	opts := ExportImagesOptions{Names: []string{}, OutputStream: &buf}
+	err := client.ExportImages(opts)
+	if err == nil {
+		t.Error("Expected an error")
+	}
+	if err != ErrMustSpecifyNames {
+		t.Error(err)
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/misc.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/misc.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -13,7 +13,7 @@ import (
 //
 // See http://goo.gl/BOZrF5 for more details.
 func (c *Client) Version() (*Env, error) {
-	body, _, err := c.do("GET", "/version", nil)
+	body, _, err := c.do("GET", "/version", doOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (c *Client) Version() (*Env, error) {
 //
 // See http://goo.gl/wmqZsW for more details.
 func (c *Client) Info() (*Env, error) {
-	body, _, err := c.do("GET", "/info", nil)
+	body, _, err := c.do("GET", "/info", doOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tar.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/tar.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -25,6 +25,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+var nameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+
 // DockerServer represents a programmable, concurrent (not much), HTTP server
 // implementing a fake version of the Docker remote API.
 //
@@ -35,6 +37,7 @@ import (
 type DockerServer struct {
 	containers     []*docker.Container
 	execs          []*docker.ExecInspect
+	execMut        sync.RWMutex
 	cMut           sync.RWMutex
 	images         []docker.Image
 	iMut           sync.RWMutex
@@ -43,6 +46,8 @@ type DockerServer struct {
 	mux            *mux.Router
 	hook           func(*http.Request)
 	failures       map[string]string
+	multiFailures  []map[string]string
+	execCallbacks  map[string]func()
 	customHandlers map[string]http.Handler
 	handlerMutex   sync.RWMutex
 	cChan          chan<- *docker.Container
@@ -69,6 +74,7 @@ func NewServer(bind string, containerChan chan<- *docker.Container, hook func(*h
 		imgIDs:         make(map[string]string),
 		hook:           hook,
 		failures:       make(map[string]string),
+		execCallbacks:  make(map[string]func()),
 		customHandlers: make(map[string]http.Handler),
 		cChan:          containerChan,
 	}
@@ -89,6 +95,7 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/containers/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.listContainers))
 	s.mux.Path("/containers/create").Methods("POST").HandlerFunc(s.handlerWrapper(s.createContainer))
 	s.mux.Path("/containers/{id:.*}/json").Methods("GET").HandlerFunc(s.handlerWrapper(s.inspectContainer))
+	s.mux.Path("/containers/{id:.*}/rename").Methods("POST").HandlerFunc(s.handlerWrapper(s.renameContainer))
 	s.mux.Path("/containers/{id:.*}/top").Methods("GET").HandlerFunc(s.handlerWrapper(s.topContainer))
 	s.mux.Path("/containers/{id:.*}/start").Methods("POST").HandlerFunc(s.handlerWrapper(s.startContainer))
 	s.mux.Path("/containers/{id:.*}/kill").Methods("POST").HandlerFunc(s.handlerWrapper(s.stopContainer))
@@ -115,15 +122,57 @@ func (s *DockerServer) buildMuxer() {
 	s.mux.Path("/images/{id:.*}/get").Methods("GET").HandlerFunc(s.handlerWrapper(s.getImage))
 }
 
+// SetHook changes the hook function used by the server.
+//
+// The hook function is a function called on every request.
+func (s *DockerServer) SetHook(hook func(*http.Request)) {
+	s.hook = hook
+}
+
+// PrepareExec adds a callback to a container exec in the fake server.
+//
+// This function will be called whenever the given exec id is started, and the
+// given exec id will remain in the "Running" start while the function is
+// running, so it's useful for emulating an exec that runs for two seconds, for
+// example:
+//
+//    opts := docker.CreateExecOptions{
+//        AttachStdin:  true,
+//        AttachStdout: true,
+//        AttachStderr: true,
+//        Tty:          true,
+//        Cmd:          []string{"/bin/bash", "-l"},
+//    }
+//    // Client points to a fake server.
+//    exec, err := client.CreateExec(opts)
+//    // handle error
+//    server.PrepareExec(exec.ID, func() {time.Sleep(2 * time.Second)})
+//    err = client.StartExec(exec.ID, docker.StartExecOptions{Tty: true}) // will block for 2 seconds
+//    // handle error
+func (s *DockerServer) PrepareExec(id string, callback func()) {
+	s.execCallbacks[id] = callback
+}
+
 // PrepareFailure adds a new expected failure based on a URL regexp it receives
 // an id for the failure.
 func (s *DockerServer) PrepareFailure(id string, urlRegexp string) {
 	s.failures[id] = urlRegexp
 }
 
+// PrepareMultiFailures enqueues a new expected failure based on a URL regexp
+// it receives an id for the failure.
+func (s *DockerServer) PrepareMultiFailures(id string, urlRegexp string) {
+	s.multiFailures = append(s.multiFailures, map[string]string{"error": id, "url": urlRegexp})
+}
+
 // ResetFailure removes an expected failure identified by the given id.
 func (s *DockerServer) ResetFailure(id string) {
 	delete(s.failures, id)
+}
+
+// ResetMultiFailures removes all enqueued failures.
+func (s *DockerServer) ResetMultiFailures() {
+	s.multiFailures = []map[string]string{}
 }
 
 // CustomHandler registers a custom handler for a specific path.
@@ -170,9 +219,11 @@ func (s *DockerServer) URL() string {
 func (s *DockerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.handlerMutex.RLock()
 	defer s.handlerMutex.RUnlock()
-	if handler, ok := s.customHandlers[r.URL.Path]; ok {
-		handler.ServeHTTP(w, r)
-		return
+	for re, handler := range s.customHandlers {
+		if m, _ := regexp.MatchString(re, r.URL.Path); m {
+			handler.ServeHTTP(w, r)
+			return
+		}
 	}
 	s.mux.ServeHTTP(w, r)
 	if s.hook != nil {
@@ -198,6 +249,19 @@ func (s *DockerServer) handlerWrapper(f func(http.ResponseWriter, *http.Request)
 				continue
 			}
 			http.Error(w, errorID, http.StatusBadRequest)
+			return
+		}
+		for i, failure := range s.multiFailures {
+			matched, err := regexp.MatchString(failure["url"], r.URL.Path)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if !matched {
+				continue
+			}
+			http.Error(w, failure["error"], http.StatusBadRequest)
+			s.multiFailures = append(s.multiFailures[:i], s.multiFailures[i+1:]...)
 			return
 		}
 		f(w, r)
@@ -277,6 +341,11 @@ func (s *DockerServer) createContainer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	name := r.URL.Query().Get("name")
+	if name != "" && !nameRegexp.MatchString(name) {
+		http.Error(w, "Invalid container name", http.StatusInternalServerError)
+		return
+	}
 	if _, err := s.findImage(config.Image); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -301,7 +370,7 @@ func (s *DockerServer) createContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	container := docker.Container{
-		Name:    r.URL.Query().Get("name"),
+		Name:    name,
 		ID:      s.generateID(),
 		Created: time.Now(),
 		Path:    path,
@@ -334,6 +403,23 @@ func (s *DockerServer) generateID() string {
 	var buf [16]byte
 	rand.Read(buf[:])
 	return fmt.Sprintf("%x", buf)
+}
+
+func (s *DockerServer) renameContainer(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	container, index, err := s.findContainer(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	copy := *container
+	copy.Name = r.URL.Query().Get("name")
+	s.cMut.Lock()
+	defer s.cMut.Unlock()
+	if s.containers[index].ID == copy.ID {
+		s.containers[index] = &copy
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *DockerServer) inspectContainer(w http.ResponseWriter, r *http.Request) {
@@ -480,12 +566,13 @@ func (s *DockerServer) waitContainer(w http.ResponseWriter, r *http.Request) {
 
 func (s *DockerServer) removeContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+	force := r.URL.Query().Get("force")
 	_, index, err := s.findContainer(id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	if s.containers[index].State.Running {
+	if s.containers[index].State.Running && force != "1" {
 		msg := "Error: API error (406): Impossible to remove a running container, please stop it first"
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
@@ -587,12 +674,16 @@ func (s *DockerServer) buildImage(w http.ResponseWriter, r *http.Request) {
 
 func (s *DockerServer) pullImage(w http.ResponseWriter, r *http.Request) {
 	fromImageName := r.URL.Query().Get("fromImage")
+	tag := r.URL.Query().Get("tag")
 	image := docker.Image{
 		ID: s.generateID(),
 	}
 	s.iMut.Lock()
 	s.images = append(s.images, image)
 	if fromImageName != "" {
+		if tag != "" {
+			fromImageName = fmt.Sprintf("%s:%s", fromImageName, tag)
+		}
 		s.imgIDs[fromImageName] = image.ID
 	}
 	s.iMut.Unlock()
@@ -734,7 +825,6 @@ func (s *DockerServer) loadImage(w http.ResponseWriter, r *http.Request) {
 func (s *DockerServer) getImage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/tar")
-
 }
 
 func (s *DockerServer) createExecContainer(w http.ResponseWriter, r *http.Request) {
@@ -745,7 +835,7 @@ func (s *DockerServer) createExecContainer(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	exec := docker.ExecInspect{
-		ID:        "id-exec-created-by-test",
+		ID:        s.generateID(),
 		Container: *container,
 	}
 	var params docker.CreateExecOptions
@@ -760,44 +850,63 @@ func (s *DockerServer) createExecContainer(w http.ResponseWriter, r *http.Reques
 			exec.ProcessConfig.Arguments = params.Cmd[1:]
 		}
 	}
+	s.execMut.Lock()
 	s.execs = append(s.execs, &exec)
+	s.execMut.Unlock()
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"Id": exec.ID})
-
 }
 
 func (s *DockerServer) startExecContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
-	for _, exec := range s.execs {
-		if exec.ID == id {
-			w.WriteHeader(http.StatusOK)
-			return
+	if exec, err := s.getExec(id); err == nil {
+		s.execMut.Lock()
+		exec.Running = true
+		s.execMut.Unlock()
+		if callback, ok := s.execCallbacks[id]; ok {
+			callback()
+			delete(s.execCallbacks, id)
+		} else if callback, ok := s.execCallbacks["*"]; ok {
+			callback()
+			delete(s.execCallbacks, "*")
 		}
+		s.execMut.Lock()
+		exec.Running = false
+		s.execMut.Unlock()
+		w.WriteHeader(http.StatusOK)
+		return
 	}
 	w.WriteHeader(http.StatusNotFound)
 }
 
 func (s *DockerServer) resizeExecContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
-	for _, exec := range s.execs {
-		if exec.ID == id {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
+	if _, err := s.getExec(id); err == nil {
+		w.WriteHeader(http.StatusOK)
+		return
 	}
 	w.WriteHeader(http.StatusNotFound)
 }
 
 func (s *DockerServer) inspectExecContainer(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
-	for _, exec := range s.execs {
-		if exec.ID == id {
-			w.WriteHeader(http.StatusOK)
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(exec)
-			return
-		}
+	if exec, err := s.getExec(id); err == nil {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(exec)
+		return
 	}
 	w.WriteHeader(http.StatusNotFound)
+}
+
+func (s *DockerServer) getExec(id string) (*docker.ExecInspect, error) {
+	s.execMut.RLock()
+	defer s.execMut.RUnlock()
+	for _, exec := range s.execs {
+		if exec.ID == id {
+			return exec, nil
+		}
+	}
+	return nil, errors.New("exec not found")
 }

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server_test.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/testing/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 go-dockerclient authors. All rights reserved.
+// Copyright 2015 go-dockerclient authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -82,6 +82,19 @@ func TestHandleWithHook(t *testing.T) {
 	}
 }
 
+func TestSetHook(t *testing.T) {
+	var called bool
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	defer server.Stop()
+	server.SetHook(func(*http.Request) { called = true })
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/containers/json?all=1", nil)
+	server.ServeHTTP(recorder, request)
+	if !called {
+		t.Error("ServeHTTP did not call the hook function.")
+	}
+}
+
 func TestCustomHandler(t *testing.T) {
 	var called bool
 	server, _ := NewServer("127.0.0.1:0", nil, nil)
@@ -92,6 +105,25 @@ func TestCustomHandler(t *testing.T) {
 	}))
 	recorder := httptest.NewRecorder()
 	request, _ := http.NewRequest("GET", "/containers/json?all=1", nil)
+	server.ServeHTTP(recorder, request)
+	if !called {
+		t.Error("Did not call the custom handler")
+	}
+	if got := recorder.Body.String(); got != "Hello world" {
+		t.Errorf("Wrong output for custom handler: want %q. Got %q.", "Hello world", got)
+	}
+}
+
+func TestCustomHandlerRegexp(t *testing.T) {
+	var called bool
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	addContainers(server, 2)
+	server.CustomHandler("/containers/.*/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		fmt.Fprint(w, "Hello world")
+	}))
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/containers/.*/json?all=1", nil)
 	server.ServeHTTP(recorder, request)
 	if !called {
 		t.Error("Did not call the custom handler")
@@ -209,6 +241,24 @@ func TestCreateContainerInvalidBody(t *testing.T) {
 	}
 }
 
+func TestCreateContainerInvalidName(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Hostname":"", "User":"", "Memory":0, "MemorySwap":0, "AttachStdin":false, "AttachStdout":true, "AttachStderr":true,
+"PortSpecs":null, "Tty":false, "OpenStdin":false, "StdinOnce":false, "Env":null, "Cmd":["date"],
+"Image":"base", "Volumes":{}, "VolumesFrom":""}`
+	request, _ := http.NewRequest("POST", "/containers/create?name=myapp/container1", strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Errorf("CreateContainer: wrong status. Want %d. Got %d.", http.StatusInternalServerError, recorder.Code)
+	}
+	expectedBody := "Invalid container name\n"
+	if got := recorder.Body.String(); got != expectedBody {
+		t.Errorf("CreateContainer: wrong body. Want %q. Got %q.", expectedBody, got)
+	}
+}
+
 func TestCreateContainerImageNotFound(t *testing.T) {
 	server := DockerServer{}
 	server.buildMuxer()
@@ -220,6 +270,35 @@ func TestCreateContainerImageNotFound(t *testing.T) {
 	server.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusNotFound {
 		t.Errorf("CreateContainer: wrong status. Want %d. Got %d.", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestRenameContainer(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 2)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	newName := server.containers[0].Name + "abc"
+	path := fmt.Sprintf("/containers/%s/rename?name=%s", server.containers[0].ID, newName)
+	request, _ := http.NewRequest("POST", path, nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("RenameContainer: wrong status. Want %d. Got %d.", http.StatusNoContent, recorder.Code)
+	}
+	container := server.containers[0]
+	if container.Name != newName {
+		t.Errorf("RenameContainer: did not rename the container. Want %q. Got %q.", newName, container.Name)
+	}
+}
+
+func TestRenameContainerNotFound(t *testing.T) {
+	server := DockerServer{}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/containers/blabla/rename?name=something", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("RenameContainer: wrong status. Want %d. Got %d.", http.StatusNotFound, recorder.Code)
 	}
 }
 
@@ -771,6 +850,23 @@ func TestRemoveContainerRunning(t *testing.T) {
 	}
 }
 
+func TestRemoveContainerRunningForce(t *testing.T) {
+	server := DockerServer{}
+	addContainers(&server, 1)
+	server.containers[0].State.Running = true
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	path := fmt.Sprintf("/containers/%s?%s", server.containers[0].ID, "force=1")
+	request, _ := http.NewRequest("DELETE", path, nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("RemoveContainer: wrong status. Want %d. Got %d.", http.StatusNoContent, recorder.Code)
+	}
+	if len(server.containers) > 0 {
+		t.Error("RemoveContainer: did not remove the container.")
+	}
+}
+
 func TestPullImage(t *testing.T) {
 	server := DockerServer{imgIDs: make(map[string]string)}
 	server.buildMuxer()
@@ -784,6 +880,23 @@ func TestPullImage(t *testing.T) {
 		t.Errorf("PullImage: Want 1 image. Got %d.", len(server.images))
 	}
 	if _, ok := server.imgIDs["base"]; !ok {
+		t.Error("PullImage: Repository should not be empty.")
+	}
+}
+
+func TestPullImageWithTag(t *testing.T) {
+	server := DockerServer{imgIDs: make(map[string]string)}
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/images/create?fromImage=base&tag=tag", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("PullImage: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if len(server.images) != 1 {
+		t.Errorf("PullImage: Want 1 image. Got %d.", len(server.images))
+	}
+	if _, ok := server.imgIDs["base:tag"]; !ok {
 		t.Error("PullImage: Repository should not be empty.")
 	}
 }
@@ -1032,6 +1145,41 @@ func TestPrepareFailure(t *testing.T) {
 	}
 }
 
+func TestPrepareMultiFailures(t *testing.T) {
+	server := DockerServer{multiFailures: []map[string]string{}}
+	server.buildMuxer()
+	errorID := "multi error"
+	server.PrepareMultiFailures(errorID, "containers/json")
+	server.PrepareMultiFailures(errorID, "containers/json")
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/containers/json?all=1", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("PrepareFailure: wrong status. Want %d. Got %d.", http.StatusBadRequest, recorder.Code)
+	}
+	if recorder.Body.String() != errorID+"\n" {
+		t.Errorf("PrepareFailure: wrong message. Want %s. Got %s.", errorID, recorder.Body.String())
+	}
+	recorder = httptest.NewRecorder()
+	request, _ = http.NewRequest("GET", "/containers/json?all=1", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("PrepareFailure: wrong status. Want %d. Got %d.", http.StatusBadRequest, recorder.Code)
+	}
+	if recorder.Body.String() != errorID+"\n" {
+		t.Errorf("PrepareFailure: wrong message. Want %s. Got %s.", errorID, recorder.Body.String())
+	}
+	recorder = httptest.NewRecorder()
+	request, _ = http.NewRequest("GET", "/containers/json?all=1", nil)
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Errorf("PrepareFailure: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	if recorder.Body.String() == errorID+"\n" {
+		t.Errorf("PrepareFailure: wrong message. Want %s. Got %s.", errorID, recorder.Body.String())
+	}
+}
+
 func TestRemoveFailure(t *testing.T) {
 	server := DockerServer{failures: make(map[string]string)}
 	server.buildMuxer()
@@ -1049,6 +1197,21 @@ func TestRemoveFailure(t *testing.T) {
 	server.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusOK {
 		t.Errorf("RemoveFailure: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+}
+
+func TestResetMultiFailures(t *testing.T) {
+	server := DockerServer{multiFailures: []map[string]string{}}
+	server.buildMuxer()
+	errorID := "multi error"
+	server.PrepareMultiFailures(errorID, "containers/json")
+	server.PrepareMultiFailures(errorID, "containers/json")
+	if len(server.multiFailures) != 2 {
+		t.Errorf("PrepareMultiFailures: error adding multi failures.")
+	}
+	server.ResetMultiFailures()
+	if len(server.multiFailures) != 0 {
+		t.Errorf("ResetMultiFailures: error reseting multi failures.")
 	}
 }
 
@@ -1214,4 +1377,133 @@ func TestInspectExecContainer(t *testing.T) {
 	if !reflect.DeepEqual(got2, expected) {
 		t.Errorf("InspectContainer: wrong value. Want:\n%#v\nGot:\n%#v\n", expected, got2)
 	}
+}
+
+func TestStartExecContainer(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	addContainers(server, 1)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Cmd": ["bash", "-c", "ls"]}`
+	path := fmt.Sprintf("/containers/%s/exec", server.containers[0].ID)
+	request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("CreateExec: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	var exec docker.Exec
+	err := json.NewDecoder(recorder.Body).Decode(&exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unleash := make(chan bool)
+	server.PrepareExec(exec.ID, func() {
+		<-unleash
+	})
+	codes := make(chan int, 1)
+	sent := make(chan bool)
+	go func() {
+		recorder := httptest.NewRecorder()
+		path := fmt.Sprintf("/exec/%s/start", exec.ID)
+		body := `{"Tty":true}`
+		request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+		close(sent)
+		server.ServeHTTP(recorder, request)
+		codes <- recorder.Code
+	}()
+	<-sent
+	execInfo, err := waitExec(server.URL(), exec.ID, true, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !execInfo.Running {
+		t.Error("StartExec: expected exec to be running, but it's not running")
+	}
+	close(unleash)
+	if code := <-codes; code != http.StatusOK {
+		t.Errorf("StartExec: wrong status. Want %d. Got %d.", http.StatusOK, code)
+	}
+	execInfo, err = waitExec(server.URL(), exec.ID, false, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if execInfo.Running {
+		t.Error("StartExec: expected exec to be not running after start returns, but it's running")
+	}
+}
+
+func TestStartExecContainerWildcardCallback(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	addContainers(server, 1)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Cmd": ["bash", "-c", "ls"]}`
+	path := fmt.Sprintf("/containers/%s/exec", server.containers[0].ID)
+	request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("CreateExec: wrong status. Want %d. Got %d.", http.StatusOK, recorder.Code)
+	}
+	unleash := make(chan bool)
+	server.PrepareExec("*", func() {
+		<-unleash
+	})
+	var exec docker.Exec
+	err := json.NewDecoder(recorder.Body).Decode(&exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	codes := make(chan int, 1)
+	sent := make(chan bool)
+	go func() {
+		recorder := httptest.NewRecorder()
+		path := fmt.Sprintf("/exec/%s/start", exec.ID)
+		body := `{"Tty":true}`
+		request, _ := http.NewRequest("POST", path, strings.NewReader(body))
+		close(sent)
+		server.ServeHTTP(recorder, request)
+		codes <- recorder.Code
+	}()
+	<-sent
+	execInfo, err := waitExec(server.URL(), exec.ID, true, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !execInfo.Running {
+		t.Error("StartExec: expected exec to be running, but it's not running")
+	}
+	close(unleash)
+	if code := <-codes; code != http.StatusOK {
+		t.Errorf("StartExec: wrong status. Want %d. Got %d.", http.StatusOK, code)
+	}
+	execInfo, err = waitExec(server.URL(), exec.ID, false, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if execInfo.Running {
+		t.Error("StartExec: expected exec to be not running after start returns, but it's running")
+	}
+}
+
+func TestStartExecContainerNotFound(t *testing.T) {
+	server, _ := NewServer("127.0.0.1:0", nil, nil)
+	addContainers(server, 1)
+	server.buildMuxer()
+	recorder := httptest.NewRecorder()
+	body := `{"Tty":true}`
+	request, _ := http.NewRequest("POST", "/exec/something-wat/start", strings.NewReader(body))
+	server.ServeHTTP(recorder, request)
+}
+
+func waitExec(url, execID string, running bool, maxTry int) (*docker.ExecInspect, error) {
+	client, err := docker.NewClient(url)
+	if err != nil {
+		return nil, err
+	}
+	exec, err := client.InspectExec(execID)
+	for i := 0; i < maxTry && exec.Running != running && err == nil; i++ {
+		time.Sleep(100e6)
+		exec, err = client.InspectExec(exec.ID)
+	}
+	return exec, err
 }

--- a/events/client.go
+++ b/events/client.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultUnixSocket = "unix:///var/run/docker.sock"
-	defaultApiVersion = "1.16"
+	defaultApiVersion = "1.18"
 )
 
 func NewDockerClient(useDockerConnectEnvVars bool) (*docker.Client, error) {

--- a/events/entry_test.go
+++ b/events/entry_test.go
@@ -35,7 +35,10 @@ func TestProcessDockerEvents(t *testing.T) {
 	}
 
 	// Create pre-existing containers before starting event listener
-	preexistRunning, _ := createNetTestContainer(dockerClient, "10.1.2.3")
+	preexistRunning, err := createNetTestContainer(dockerClient, "10.1.2.3")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if err := dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: preexistRunning.ID, Force: true,
 			RemoveVolumes: true}); err != nil {

--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -17,7 +17,8 @@ import (
 	"github.com/rancherio/go-machine-service/locks"
 )
 
-const RancherIPKey = "RANCHER_IP="
+const RancherIPLabelKey = "io.rancher.container.ip"
+const RancherIPEnvKey = "RANCHER_IP="
 const RancherNameserver = "169.254.169.250"
 
 type StartHandler struct {
@@ -112,9 +113,12 @@ func (h *StartHandler) Handle(event *docker.APIEvents) error {
 }
 
 func (h *StartHandler) getRancherIP(c *docker.Container) (string, error) {
+	if ip, ok := c.Config.Labels[RancherIPLabelKey]; ok {
+		return ip, nil
+	}
 	for _, env := range c.Config.Env {
-		if strings.HasPrefix(env, RancherIPKey) {
-			return strings.TrimPrefix(env, RancherIPKey), nil
+		if strings.HasPrefix(env, RancherIPEnvKey) {
+			return strings.TrimPrefix(env, RancherIPEnvKey), nil
 		}
 	}
 

--- a/events/start_handler_test.go
+++ b/events/start_handler_test.go
@@ -27,6 +27,23 @@ func TestStartHandlerHappyPath(t *testing.T) {
 	}
 	defer dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: c.ID, Force: true, RemoveVolumes: true})
 
+	assertIpInject(injectedIp, c, dockerClient, t)
+}
+
+func TestStartHandlerEnvVar(t *testing.T) {
+	dockerClient := prep(t)
+
+	injectedIp := "10.1.2.3"
+	c, err := createNetTestContainerNoLabel(dockerClient, injectedIp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: c.ID, Force: true, RemoveVolumes: true})
+
+	assertIpInject(injectedIp, c, dockerClient, t)
+}
+
+func assertIpInject(injectedIp string, c *docker.Container, dockerClient *docker.Client, t *testing.T) {
 	if err := dockerClient.StartContainer(c.ID, &docker.HostConfig{}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Start using a real label for the rancher ip address on a container.

***Dont merge. This requires some coordination because it requires that we upgrade to 1.6.***
I'll coordinate with @ibuildthecloud and @cloudnautique on when it can be merged.