### PR TITLE
Mark startup events as simulated

### DIFF
--- a/events/entry.go
+++ b/events/entry.go
@@ -60,6 +60,7 @@ func (de *DockerEventsProcessor) Process() error {
 		event := &docker.APIEvents{
 			ID:     c.ID,
 			Status: "start",
+			From:   simulatedEvent,
 		}
 		router.listener <- event
 	}

--- a/events/entry_test.go
+++ b/events/entry_test.go
@@ -76,6 +76,9 @@ func TestProcessDockerEvents(t *testing.T) {
 			if e.ID == preexistPaused.ID {
 				waitingOnPaused = false
 			}
+			if e.From != simulatedEvent {
+				t.Fatalf("Startup event was not marked as simulated. From value: [%v]", e.From)
+			}
 		case <-time.After(10 * time.Second):
 			t.Fatalf("Never received event for preexisting container [%v]", preexistRunning.ID)
 		}


### PR DESCRIPTION
An oversight; they need this marker so that they aren't sent to cattle.