### PR TITLE
Healtcheck: do nothing on partial UP

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -89,7 +89,8 @@ func (m *Monitor) processStat(stat haproxy.Stat) {
 
 	previousStatus := m.reportedStatus[serverName]
 	if strings.HasPrefix(currentStatus, "UP ") {
-		currentStatus = "UP"
+		// do nothing on partial UP
+		return
 	}
 
 	if previousStatus != currentStatus {


### PR DESCRIPTION
Tested:

1) Positive scenario - healthcheck is configured correctly. The first event is always Down, meaning the partial UP never sent to cattle:

mysql> select id, healthcheck_instance_id, reported_health  from service_event where instance_id in (select id from instance where name like '%test%') order by healthcheck_instance_id, id;
+----+-------------------------+-----------------+
| id | healthcheck_instance_id | reported_health |
+----+-------------------------+-----------------+
| 24 |                      17 | UP              |
| 23 |                      18 | DOWN            |
| 30 |                      18 | DOWN 1/2        |
| 31 |                      18 | UP              |
| 28 |                      19 | DOWN            |
| 35 |                      19 | DOWN 1/2        |
| 40 |                      19 | UP              |


2) Negative scenario (port or http dest page is misconfigured). The first - and only- event is always DOWN

3) Tested the same use case as in 1), but with a very short checkInterval/timeout. Results are the same

4) Tested with long check interval and short timeout. Results are the same.